### PR TITLE
feat: support 'optional' instruction accounts

### DIFF
--- a/shank-idl/src/idl_instruction.rs
+++ b/shank-idl/src/idl_instruction.rs
@@ -127,6 +127,9 @@ impl From<InstructionAccount> for IdlAccountItem {
     }
 }
 
+fn is_false(x: &bool) -> bool {
+    return !x;
+}
 // -----------------
 // IdlAccount
 // -----------------
@@ -138,6 +141,8 @@ pub struct IdlAccount {
     pub is_signer: bool,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub desc: Option<String>,
+    #[serde(skip_serializing_if = "is_false", default)]
+    pub optional: bool,
 }
 
 impl From<InstructionAccount> for IdlAccount {
@@ -147,6 +152,7 @@ impl From<InstructionAccount> for IdlAccount {
             writable,
             signer,
             desc,
+            optional,
             ..
         } = acc;
         Self {
@@ -154,6 +160,7 @@ impl From<InstructionAccount> for IdlAccount {
             is_mut: writable,
             is_signer: signer,
             desc,
+            optional,
         }
     }
 }

--- a/shank-idl/tests/fixtures/instructions/single_file/instruction_with_optional_account.json
+++ b/shank-idl/tests/fixtures/instructions/single_file/instruction_with_optional_account.json
@@ -1,0 +1,52 @@
+{
+  "version": "",
+  "name": "",
+  "instructions": [
+    {
+      "name": "CreateThing",
+      "accounts": [
+        {
+          "name": "creator",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "thing",
+          "isMut": true,
+          "isSigner": false,
+          "optional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "someArgs",
+          "type": {
+            "defined": "SomeArgs"
+          }
+        }
+      ],
+      "discriminant": {
+        "type": "u8",
+        "value": 0
+      }
+    },
+    {
+      "name": "CloseThing",
+      "accounts": [
+        {
+          "name": "creator",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [],
+      "discriminant": {
+        "type": "u8",
+        "value": 1
+      }
+    }
+  ],
+  "metadata": {
+    "origin": "shank"
+  }
+}

--- a/shank-idl/tests/fixtures/instructions/single_file/instruction_with_optional_account.rs
+++ b/shank-idl/tests/fixtures/instructions/single_file/instruction_with_optional_account.rs
@@ -1,0 +1,8 @@
+#[derive(ShankInstruction)]
+pub enum Instruction {
+    #[account(0, name = "creator", sig)]
+    #[account(1, name = "thing", mut, optional)]
+    CreateThing(SomeArgs),
+    #[account(name = "creator", sig)]
+    CloseThing,
+}

--- a/shank-idl/tests/instructions.rs
+++ b/shank-idl/tests/instructions.rs
@@ -44,6 +44,23 @@ fn instruction_from_single_file_with_args() {
 }
 
 #[test]
+fn instruction_from_single_file_with_optional_account() {
+    let file = fixtures_dir()
+        .join("single_file")
+        .join("instruction_with_optional_account.rs");
+    let idl = parse_file(&file, &ParseIdlConfig::optional_program_address())
+        .expect("Parsing should not fail")
+        .expect("File contains IDL");
+
+    let expected_idl: Idl = serde_json::from_str(include_str!(
+        "./fixtures/instructions/single_file/instruction_with_optional_account.json"
+    ))
+    .unwrap();
+
+    assert_eq!(idl, expected_idl);
+}
+
+#[test]
 fn instruction_from_single_file_invalid_attr() {
     let file = fixtures_dir()
         .join("single_file")

--- a/shank-macro-impl/src/instruction/account_attrs.rs
+++ b/shank-macro-impl/src/instruction/account_attrs.rs
@@ -16,6 +16,7 @@ pub struct InstructionAccount {
     pub writable: bool,
     pub signer: bool,
     pub desc: Option<String>,
+    pub optional: bool,
 }
 
 #[derive(Debug, PartialEq)]
@@ -69,6 +70,7 @@ impl InstructionAccount {
         let mut signer = false;
         let mut desc = None;
         let mut account_name = None;
+        let mut optional = false;
 
         for meta in nested {
             if let Some((ident, name, value)) =
@@ -92,12 +94,13 @@ impl InstructionAccount {
             } else if let Some((ident, name)) =
                 identifier_from_nested_meta(meta)
             {
-                // signer, writable ...
+                // signer, writable, optional ...
                 match name.as_str() {
                     "signer" | "sign" | "sig" | "s" => signer = true,
                     "writable" | "write" | "writ" | "mut" | "w" => {
                         writable = true;
                     }
+                    "optional" | "option" | "opt" => optional = true,
                     _ => {
                         return Err(ParseError::new_spanned(
                             ident,
@@ -128,6 +131,7 @@ impl InstructionAccount {
                 writable,
                 signer,
                 desc,
+                optional,
             }),
             None => {
                 Err(ParseError::new_spanned(nested, "Missing account name"))

--- a/shank-macro-impl/src/instruction/instruction_test.rs
+++ b/shank-macro-impl/src/instruction/instruction_test.rs
@@ -38,7 +38,7 @@ fn parse_c_style_instruction() {
         #[derive(ShankInstruction)]
         pub enum Instruction {
             #[account(0, name = "creator", sig)]
-            #[account(1, name = "thing", mut)]
+            #[account(1, name = "thing", mut, optional)]
             CreateThing,
             #[account(name = "creator", sig)]
             CloseThing
@@ -49,6 +49,18 @@ fn parse_c_style_instruction() {
 
     assert_eq!(parsed.ident.to_string(), "Instruction", "enum ident");
     assert_eq!(parsed.variants.len(), 2, "variants");
+    assert_eq!(
+        parsed.variants[0].accounts[0].optional, false,
+        "non-optional account of first variant"
+    );
+    assert_eq!(
+        parsed.variants[0].accounts[1].optional, true,
+        "optional account of first variant"
+    );
+    assert_eq!(
+        parsed.variants[1].accounts[0].optional, false,
+        "non-optional account of second variant"
+    );
 
     assert_instruction_variant(&parsed.variants[0], "CreateThing", 0, None, 2);
     assert_instruction_variant(&parsed.variants[1], "CloseThing", 1, None, 1);


### PR DESCRIPTION
Added `#[account(optional)]` flag which adds `optional: true` for the IDL definition for the
instruction account annotated with that flag.
