### PR TITLE
feat: acccount padding support

### DIFF
--- a/shank-idl/src/idl_field.rs
+++ b/shank-idl/src/idl_field.rs
@@ -12,15 +12,25 @@ pub struct IdlField {
     pub name: String,
     #[serde(rename = "type")]
     pub ty: IdlType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attrs: Option<Vec<String>>,
 }
 
 impl TryFrom<StructField> for IdlField {
     type Error = Error;
     fn try_from(field: StructField) -> Result<Self> {
         let ty: IdlType = field.rust_type.try_into()?;
+        let attrs = field
+            .attrs
+            .iter()
+            .map(Into::<String>::into)
+            .collect::<Vec<String>>();
+
+        let attrs = if attrs.is_empty() { None } else { Some(attrs) };
         Ok(Self {
             name: field.ident.to_string().to_mixed_case(),
             ty,
+            attrs,
         })
     }
 }

--- a/shank-idl/src/idl_instruction.rs
+++ b/shank-idl/src/idl_instruction.rs
@@ -62,7 +62,11 @@ impl TryFrom<InstructionVariant> for IdlInstruction {
                 "instructionArgs".to_string()
             };
             let ty = IdlType::try_from(field_ty)?;
-            vec![IdlField { name, ty }]
+            vec![IdlField {
+                name,
+                ty,
+                attrs: None,
+            }]
         } else {
             vec![]
         };

--- a/shank-idl/tests/accounts.rs
+++ b/shank-idl/tests/accounts.rs
@@ -57,6 +57,16 @@ fn account_from_single_file_complex_types() {
 }
 
 #[test]
+fn account_from_single_file_padding() {
+    let file = fixtures_dir().join("single_file").join("padding.rs");
+    let idl = parse_file(&file, &ParseIdlConfig::optional_program_address())
+        .expect("Parsing should not fail")
+        .expect("File contains IDL");
+
+    check_or_update_idl(&idl, "single_file/padding.json");
+}
+
+#[test]
 fn account_from_crate() {
     let file = fixtures_dir()
         .join("sample_crate")

--- a/shank-idl/tests/fixtures/accounts/single_file/padding.json
+++ b/shank-idl/tests/fixtures/accounts/single_file/padding.json
@@ -1,0 +1,34 @@
+{
+  "version": "",
+  "name": "",
+  "instructions": [],
+  "accounts": [
+    {
+      "name": "StructAccountWithPadding",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "count",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            },
+            "attrs": [
+              "padding"
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "metadata": {
+    "origin": "shank"
+  }
+}

--- a/shank-idl/tests/fixtures/accounts/single_file/padding.rs
+++ b/shank-idl/tests/fixtures/accounts/single_file/padding.rs
@@ -1,0 +1,6 @@
+#[derive(ShankAccount)]
+pub struct StructAccountWithPadding {
+    count: u8,
+    #[padding]
+    _padding: [u8; 3],
+}

--- a/shank-macro-impl/src/parsed_struct/mod.rs
+++ b/shank-macro-impl/src/parsed_struct/mod.rs
@@ -1,8 +1,10 @@
 use proc_macro2::TokenStream;
 
 mod parsed_struct;
+mod struct_field_attr;
 
 pub use parsed_struct::*;
+pub use struct_field_attr::StructFieldAttr;
 
 #[cfg(test)]
 mod parsed_struct_test;

--- a/shank-macro-impl/src/parsed_struct/parsed_struct.rs
+++ b/shank-macro-impl/src/parsed_struct/parsed_struct.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashSet,
     convert::{TryFrom, TryInto},
     fmt::Display,
 };
@@ -11,10 +12,13 @@ use syn::{
 
 use crate::types::RustType;
 
+use super::struct_field_attr::{StructFieldAttr, StructFieldAttrs};
+
 #[derive(Debug, Clone)]
 pub struct StructField {
     pub ident: syn::Ident,
     pub rust_type: RustType,
+    pub attrs: HashSet<StructFieldAttr>,
 }
 
 impl Display for StructField {
@@ -34,13 +38,19 @@ impl TryFrom<&Field> for StructField {
 
     fn try_from(f: &Field) -> ParseResult<Self> {
         let ident = f.ident.as_ref().unwrap().clone();
+        let attrs = StructFieldAttrs::from(f.attrs.as_ref()).0;
         let rust_type: RustType = match (&f.ty).try_into() {
             Ok(ty) => ty,
             Err(err) => {
                 return Err(ParseError::new_spanned(ident, err.to_string()))
             }
         };
-        Ok(Self { ident, rust_type })
+
+        Ok(Self {
+            ident,
+            rust_type,
+            attrs,
+        })
     }
 }
 

--- a/shank-macro-impl/src/parsed_struct/struct_field_attr.rs
+++ b/shank-macro-impl/src/parsed_struct/struct_field_attr.rs
@@ -7,6 +7,14 @@ pub enum StructFieldAttr {
     Padding,
 }
 
+impl From<&StructFieldAttr> for String {
+    fn from(attr: &StructFieldAttr) -> Self {
+        match attr {
+            StructFieldAttr::Padding => "padding".to_string(),
+        }
+    }
+}
+
 pub struct StructFieldAttrs(pub HashSet<StructFieldAttr>);
 
 impl From<&[Attribute]> for StructFieldAttrs {

--- a/shank-macro-impl/src/parsed_struct/struct_field_attr.rs
+++ b/shank-macro-impl/src/parsed_struct/struct_field_attr.rs
@@ -1,0 +1,27 @@
+use std::collections::HashSet;
+
+use syn::Attribute;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum StructFieldAttr {
+    Padding,
+}
+
+pub struct StructFieldAttrs(pub HashSet<StructFieldAttr>);
+
+impl From<&[Attribute]> for StructFieldAttrs {
+    fn from(attrs: &[Attribute]) -> Self {
+        Self(
+            attrs
+                .iter()
+                .filter_map(|attr| {
+                    if attr.path.is_ident("padding") {
+                        Some(StructFieldAttr::Padding)
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+        )
+    }
+}

--- a/shank-macro/src/lib.rs
+++ b/shank-macro/src/lib.rs
@@ -31,7 +31,7 @@ mod instruction;
 ///
 /// The fields of a _ShankAccount_ struct can reference other types as long as they are annotated
 /// with `BorshSerialize` or `BorshDeserialize`.
-#[proc_macro_derive(ShankAccount)]
+#[proc_macro_derive(ShankAccount, attributes(padding))]
 pub fn shank_account(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     derive_account(input)


### PR DESCRIPTION
# Summary

Adds support to declare an account field as padding.

```rs
#[derive(ShankAccount)]
pub struct StructAccountWithPadding {
    count: u8,
    #[padding]
    _padding: [u8; 3],
}
```

This attribute is included in the Account IDL `attrs` as `"padding"`.

## Details

This required changes to:

- `shank-macro` to add the attr to `ShankAccount` derive
- `shank-macro-impl` in order to parse the new attribute.
- `shank-idl` in order to include the attribute in the IDL of accounts

## Related Work

Solita is updated in [this PR](https://github.com/metaplex-foundation/solita/pull/59) to adapt the rendered code for Accounts with padding.

Fixes: #17
