### PR TITLE
fix: data enum mapping variants with named fields correctly

### DIFF
--- a/shank-idl/tests/errors.rs
+++ b/shank-idl/tests/errors.rs
@@ -14,7 +14,7 @@ fn errors_this_error() {
         .expect("Parsing should not fail")
         .expect("File contains IDL");
 
-    eprintln!("{}", idl.try_into_json().unwrap());
+    // eprintln!("{}", idl.try_into_json().unwrap());
 
     let expected_idl: Idl =
         serde_json::from_str(include_str!("./fixtures/errors/this_error.json"))

--- a/shank-idl/tests/fixtures/types/valid_single_data_enum.json
+++ b/shank-idl/tests/fixtures/types/valid_single_data_enum.json
@@ -1,0 +1,48 @@
+{
+  "version": "",
+  "name": "",
+  "instructions": [],
+  "types": [
+    {
+      "name": "CollectionInfo",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "V1",
+            "fields": [
+              {
+                "name": "symbol",
+                "type": "string"
+              },
+              {
+                "name": "verified_creators",
+                "type": {
+                  "vec": "publicKey"
+                }
+              },
+              {
+                "name": "whitelist_root",
+                "type": {
+                  "array": ["u8", 32]
+                }
+              }
+            ]
+          },
+          {
+            "name": "V2",
+            "fields": [
+              {
+                "name": "collection_mint",
+                "type": "publicKey"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "metadata": {
+    "origin": "shank"
+  }
+}

--- a/shank-idl/tests/fixtures/types/valid_single_data_enum.rs
+++ b/shank-idl/tests/fixtures/types/valid_single_data_enum.rs
@@ -1,0 +1,12 @@
+// https://github.com/metaplex-foundation/solita/issues/53#issuecomment-1133910360
+#[derive(BorshSerialize)]
+pub enum CollectionInfo {
+    V1 {
+        symbol: String,
+        verified_creators: Vec<Pubkey>,
+        whitelist_root: [u8; 32],
+    },
+    V2 {
+        collection_mint: Pubkey,
+    },
+}

--- a/shank-idl/tests/types.rs
+++ b/shank-idl/tests/types.rs
@@ -44,14 +44,12 @@ fn type_valid_single_data_emum() {
         .expect("Parsing should not fail")
         .expect("File contains IDL");
 
-    eprintln!("{}", serde_json::to_string_pretty(&idl).unwrap());
-
-    let _expected_idl: Idl = serde_json::from_str(include_str!(
+    let expected_idl: Idl = serde_json::from_str(include_str!(
         "./fixtures/types/valid_single_data_enum.json"
     ))
     .unwrap();
 
-    // assert_eq!(idl, expected_idl);
+    assert_eq!(idl, expected_idl);
 }
 
 #[test]

--- a/shank-idl/tests/types.rs
+++ b/shank-idl/tests/types.rs
@@ -38,6 +38,23 @@ fn type_valid_single_emum() {
 }
 
 #[test]
+fn type_valid_single_data_emum() {
+    let file = fixtures_dir().join("valid_single_data_enum.rs");
+    let idl = parse_file(&file, &ParseIdlConfig::optional_program_address())
+        .expect("Parsing should not fail")
+        .expect("File contains IDL");
+
+    eprintln!("{}", serde_json::to_string_pretty(&idl).unwrap());
+
+    let _expected_idl: Idl = serde_json::from_str(include_str!(
+        "./fixtures/types/valid_single_data_enum.json"
+    ))
+    .unwrap();
+
+    // assert_eq!(idl, expected_idl);
+}
+
+#[test]
 fn type_valid_multiple() {
     let file = fixtures_dir().join("valid_multiple.rs");
     let idl = parse_file(&file, &ParseIdlConfig::optional_program_address())

--- a/shank-macro-impl/src/parsed_enum/parsed_enum_variant.rs
+++ b/shank-macro-impl/src/parsed_enum/parsed_enum_variant.rs
@@ -86,6 +86,9 @@ pub struct ParsedEnumVariantField {
     /// The Rust type of the field
     pub rust_type: RustType,
 
+    /// Name of the field, not present for tuple fields
+    pub ident: Option<Ident>,
+
     /// The slot (starting with 0) of the field
     pub slot: usize,
 }
@@ -95,6 +98,10 @@ impl TryFrom<(usize, &Field)> for ParsedEnumVariantField {
 
     fn try_from((slot, field): (usize, &Field)) -> ParseResult<Self> {
         let rust_type = RustType::try_from(&field.ty)?;
-        Ok(ParsedEnumVariantField { rust_type, slot })
+        Ok(ParsedEnumVariantField {
+            rust_type,
+            ident: field.ident.clone(),
+            slot,
+        })
     }
 }


### PR DESCRIPTION
See [this comment in original solita issue](https://github.com/metaplex-foundation/solita/issues/64#issuecomment-1176406407).