### PR TITLE
feat: supporting hashmap and btreemap fully

### DIFF
--- a/shank-idl/src/idl_type.rs
+++ b/shank-idl/src/idl_type.rs
@@ -99,6 +99,11 @@ impl TryFrom<RustType> for IdlType {
                         "Rust HashMap Composite IDL type not yet supported"
                     )
                 }
+                Composite::BTreeMap => {
+                    anyhow::bail!(
+                        "Rust BTreeMap Composite IDL type not yet supported"
+                    )
+                }
                 Composite::Custom(_) => {
                     anyhow::bail!(
                         "Rust Custom Composite IDL type not yet supported"

--- a/shank-idl/tests/fixtures/types/valid_multiple_maps.json
+++ b/shank-idl/tests/fixtures/types/valid_multiple_maps.json
@@ -110,6 +110,30 @@
           }
         ]
       }
+    },
+    {
+      "name": "NestedMapsStruct",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vecHashMapU8U8",
+            "type": {
+              "vec": {
+                "hashMap": ["u8", "u8"]
+              }
+            }
+          },
+          {
+            "name": "optionBtreeMapU8U8",
+            "type": {
+              "option": {
+                "bTreeMap": ["u8", "u8"]
+              }
+            }
+          }
+        ]
+      }
     }
   ],
   "metadata": {

--- a/shank-idl/tests/fixtures/types/valid_multiple_maps.json
+++ b/shank-idl/tests/fixtures/types/valid_multiple_maps.json
@@ -1,0 +1,118 @@
+{
+  "version": "",
+  "name": "",
+  "instructions": [],
+  "types": [
+    {
+      "name": "OneHashMapStruct",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "u8U8Map",
+            "type": {
+              "hashMap": ["u8", "u8"]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MultipleHashMapsStruct",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "u8StringMap",
+            "type": {
+              "hashMap": ["u8", "string"]
+            }
+          },
+          {
+            "name": "stringOptionI128Map",
+            "type": {
+              "hashMap": [
+                "string",
+                {
+                  "option": "i128"
+                }
+              ]
+            }
+          },
+          {
+            "name": "optionStringVecCustomMap",
+            "type": {
+              "hashMap": [
+                {
+                  "option": "string"
+                },
+                {
+                  "vec": {
+                    "defined": "Custom"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "OneBTreeMapStruct",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "u8U8Map",
+            "type": {
+              "bTreeMap": ["u8", "u8"]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MultipleMapsStruct",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "u8StringBtreeMap",
+            "type": {
+              "bTreeMap": ["u8", "string"]
+            }
+          },
+          {
+            "name": "optionStringVecCustomBtreeMap",
+            "type": {
+              "bTreeMap": [
+                {
+                  "option": "string"
+                },
+                {
+                  "vec": {
+                    "defined": "Custom"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "i16OptionBoolHashMap",
+            "type": {
+              "hashMap": [
+                "i16",
+                {
+                  "option": "bool"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "metadata": {
+    "origin": "shank"
+  }
+}

--- a/shank-idl/tests/fixtures/types/valid_multiple_maps.rs
+++ b/shank-idl/tests/fixtures/types/valid_multiple_maps.rs
@@ -1,0 +1,24 @@
+#[derive(BorshSerialize)]
+pub struct OneHashMapStruct {
+    pub u8_u8_map: HashMap<u8, u8>,
+}
+
+#[derive(BorshSerialize)]
+pub struct MultipleHashMapsStruct {
+    pub u8_string_map: HashMap<u8, String>,
+    pub string_option_i128_map: HashMap<String, Option<i128>>,
+    pub option_string_vec_custom_map: HashMap<Option<String>, Vec<Custom>>,
+}
+
+#[derive(BorshSerialize)]
+pub struct OneBTreeMapStruct {
+    pub u8_u8_map: BTreeMap<u8, u8>,
+}
+
+#[derive(BorshSerialize)]
+pub struct MultipleMapsStruct {
+    pub u8_string_btree_map: BTreeMap<u8, String>,
+    pub option_string_vec_custom_btree_map:
+        BTreeMap<Option<String>, Vec<Custom>>,
+    pub i16_option_bool_hash_map: HashMap<i16, Option<bool>>,
+}

--- a/shank-idl/tests/fixtures/types/valid_multiple_maps.rs
+++ b/shank-idl/tests/fixtures/types/valid_multiple_maps.rs
@@ -22,3 +22,9 @@ pub struct MultipleMapsStruct {
         BTreeMap<Option<String>, Vec<Custom>>,
     pub i16_option_bool_hash_map: HashMap<i16, Option<bool>>,
 }
+
+#[derive(BorshSerialize)]
+pub struct NestedMapsStruct {
+    pub vec_hash_map_u8_u8: Vec<HashMap<u8, u8>>,
+    pub option_btree_map_u8_u8: Option<BTreeMap<u8, u8>>,
+}

--- a/shank-idl/tests/types.rs
+++ b/shank-idl/tests/types.rs
@@ -75,3 +75,19 @@ fn type_invalid_single() {
         parse_file(&file, &ParseIdlConfig::optional_program_address()).is_err()
     )
 }
+
+#[test]
+fn type_valid_maps() {
+    let file = fixtures_dir().join("valid_multiple_maps.rs");
+    let idl = parse_file(&file, &ParseIdlConfig::optional_program_address())
+        .expect("Parsing should not fail")
+        .expect("File contains IDL");
+    // eprintln!("{}", serde_json::to_string_pretty(&idl).unwrap());
+
+    let expected_idl: Idl = serde_json::from_str(include_str!(
+        "./fixtures/types/valid_multiple_maps.json"
+    ))
+    .unwrap();
+
+    assert_eq!(idl, expected_idl);
+}

--- a/shank-macro-impl/src/types/resolve_rust_ty.rs
+++ b/shank-macro-impl/src/types/resolve_rust_ty.rs
@@ -262,23 +262,36 @@ fn ident_to_kind(ident: &Ident, arguments: &PathArguments) -> TypeKind {
                 1 => match &args[0] {
                     GenericArgument::Type(ty) => match ident_str.as_str() {
                         "Vec" => {
-                            let inner = resolve_rust_ty(ty, RustTypeContext::CollectionItem)
-                                .ok()
-                                .map(|x| Box::new(x));
+                            let inner = resolve_rust_ty(
+                                ty,
+                                RustTypeContext::CollectionItem,
+                            )
+                            .ok()
+                            .map(|x| Box::new(x));
                             TypeKind::Composite(Composite::Vec, inner, None)
                         }
                         "Option" => {
-                            let inner = resolve_rust_ty(ty, RustTypeContext::OptionItem)
-                                .ok()
-                                .map(|x| Box::new(x));
+                            let inner = resolve_rust_ty(
+                                ty,
+                                RustTypeContext::OptionItem,
+                            )
+                            .ok()
+                            .map(|x| Box::new(x));
                             TypeKind::Composite(Composite::Option, inner, None)
                         }
                         _ => {
-                            let inner = resolve_rust_ty(ty, RustTypeContext::CustomItem)
-                                .ok()
-                                .map(|x| Box::new(x));
+                            let inner = resolve_rust_ty(
+                                ty,
+                                RustTypeContext::CustomItem,
+                            )
+                            .ok()
+                            .map(|x| Box::new(x));
 
-                            TypeKind::Composite(Composite::Custom(ident_str.clone()), inner, None)
+                            TypeKind::Composite(
+                                Composite::Custom(ident_str.clone()),
+                                inner,
+                                None,
+                            )
                         }
                     },
                     _ => TypeKind::Unknown,
@@ -287,29 +300,46 @@ fn ident_to_kind(ident: &Ident, arguments: &PathArguments) -> TypeKind {
                 // Two Type Parameters
                 // -----------------
                 2 => match (&args[0], &args[1]) {
-                    (GenericArgument::Type(ty1), GenericArgument::Type(ty2)) => {
-                        match ident_str.as_str() {
-                            "HashMap" => {
-                                let inner1 = resolve_rust_ty(ty1, RustTypeContext::CollectionItem)
-                                    .ok()
-                                    .map(|x| Box::new(x));
-                                let inner2 = resolve_rust_ty(ty2, RustTypeContext::CollectionItem)
-                                    .ok()
-                                    .map(|x| Box::new(x));
-                                TypeKind::Composite(Composite::HashMap, inner1, inner2)
-                            }
-                            _ => todo!(
-                            "Not yet handling custom angle bracketed types with {} type parameters",
-                            args.len()
-                        ),
+                    (
+                        GenericArgument::Type(ty1),
+                        GenericArgument::Type(ty2),
+                    ) => match ident_str.as_str() {
+                        "HashMap" => {
+                            let inner1 = resolve_rust_ty(
+                                ty1,
+                                RustTypeContext::CollectionItem,
+                            )
+                            .ok()
+                            .map(|x| Box::new(x));
+                            let inner2 = resolve_rust_ty(
+                                ty2,
+                                RustTypeContext::CollectionItem,
+                            )
+                            .ok()
+                            .map(|x| Box::new(x));
+                            TypeKind::Composite(
+                                Composite::HashMap,
+                                inner1,
+                                inner2,
+                            )
                         }
-                    }
+                        _ => {
+                            eprintln!("ident: {:#?}, args: {:#?}", ident, args);
+                            todo!(
+                                "Not yet handling custom angle bracketed types with {} type parameters",
+                                args.len()
+                            )
+                        }
+                    },
                     _ => TypeKind::Unknown,
                 },
-                _ => todo!(
-                    "Not yet handling angle bracketed types with more {} type parameters",
-                    args.len()
-                ),
+                _ => {
+                    eprintln!("ident: {:#?}, args: {:#?}", ident, args);
+                    todo!(
+                        "Not yet handling angle bracketed types with more {} type parameters",
+                        args.len()
+                    )
+                }
             }
         }
         PathArguments::Parenthesized(args) => {

--- a/shank-macro-impl/src/types/resolve_rust_ty.rs
+++ b/shank-macro-impl/src/types/resolve_rust_ty.rs
@@ -304,7 +304,7 @@ fn ident_to_kind(ident: &Ident, arguments: &PathArguments) -> TypeKind {
                         GenericArgument::Type(ty1),
                         GenericArgument::Type(ty2),
                     ) => match ident_str.as_str() {
-                        "HashMap" => {
+                        ident if ident == "HashMap" || ident == "BTreeMap" => {
                             let inner1 = resolve_rust_ty(
                                 ty1,
                                 RustTypeContext::CollectionItem,
@@ -317,11 +317,13 @@ fn ident_to_kind(ident: &Ident, arguments: &PathArguments) -> TypeKind {
                             )
                             .ok()
                             .map(|x| Box::new(x));
-                            TypeKind::Composite(
-                                Composite::HashMap,
-                                inner1,
-                                inner2,
-                            )
+
+                            let composite = if ident == "HashMap" {
+                                Composite::HashMap
+                            } else {
+                                Composite::BTreeMap
+                            };
+                            TypeKind::Composite(composite, inner1, inner2)
                         }
                         _ => {
                             eprintln!("ident: {:#?}, args: {:#?}", ident, args);

--- a/shank-macro-impl/src/types/type_kind.rs
+++ b/shank-macro-impl/src/types/type_kind.rs
@@ -152,15 +152,25 @@ impl TypeKind {
         match self {
             TypeKind::Primitive(_) => None,
             TypeKind::Value(_) => None,
-            TypeKind::Composite(Composite::HashMap, key_ty, val_ty) => {
+            TypeKind::Composite(composite, key_ty, val_ty)
+                if composite == &Composite::HashMap
+                    || composite == &Composite::BTreeMap =>
+            {
                 let key = key_ty
                     .as_ref()
                     .map(|x| *x.clone())
-                    .expect("hashmap should have key type");
+                    .ok_or_else(|| {
+                        format!("{:?} should have key type", composite)
+                    })
+                    .unwrap();
+
                 let val = val_ty
                     .as_ref()
                     .map(|x| *x.clone())
-                    .expect("hashmap should have val type");
+                    .ok_or_else(|| {
+                        format!("{:?} should have val type", composite)
+                    })
+                    .unwrap();
 
                 Some((key, val))
             }
@@ -277,6 +287,7 @@ pub enum Composite {
     Array(usize),
     Option,
     HashMap,
+    BTreeMap,
     Custom(String),
 }
 
@@ -287,6 +298,7 @@ impl Debug for Composite {
             Composite::Array(size) => write!(f, "Composite::Array({})", size),
             Composite::Option => write!(f, "Composite::Option"),
             Composite::HashMap => write!(f, "Composite::HashMap"),
+            Composite::BTreeMap => write!(f, "Composite::BTreeMap"),
             Composite::Custom(name) => {
                 write!(f, "Composite::Custom(\"{}\")", name)
             }


### PR DESCRIPTION
## Summary

Adds support for `HashMap` and `BTreeMap` field types.

They are added to the IDL as `hashMap` and `btreeMap` respectively.
i.e. for `HashMap<String, Vec<Custom>>`.

```json
{
  "type": {
    "hashMap": [
      {
        "option": "string"
      },
      {
        "vec": {
          "defined": "Custom"
        }
      }
    ]
  }
}
```

## Remaining

As more map types need support they can be added using a similar approach.
