### PR TITLE
feat: tuple support

### DIFF
--- a/shank-idl/src/idl_type.rs
+++ b/shank-idl/src/idl_type.rs
@@ -61,10 +61,10 @@ impl TryFrom<RustType> for IdlType {
                     }
                 }
             },
-            TypeKind::Composite(kind, inner1, inner2) => match kind {
-                Composite::Vec => match inner1 {
+            TypeKind::Composite(kind, inners) => match kind {
+                Composite::Vec => match inners.get(0).cloned() {
                     Some(inner) => {
-                        let inner_idl: IdlType = (*inner).try_into()?;
+                        let inner_idl: IdlType = inner.try_into()?;
                         if inner_idl == IdlType::U8 {
                             // Vec<u8>
                             IdlType::Bytes
@@ -76,9 +76,9 @@ impl TryFrom<RustType> for IdlType {
                         anyhow::bail!("Rust Vec Composite needs inner type")
                     }
                 },
-                Composite::Array(size) => match inner1 {
+                Composite::Array(size) => match inners.get(0).cloned() {
                     Some(inner) => {
-                        let inner_idl: IdlType = (*inner).try_into()?;
+                        let inner_idl: IdlType = inner.try_into()?;
                         IdlType::Array(Box::new(inner_idl), size)
                     }
                     None => {
@@ -86,40 +86,40 @@ impl TryFrom<RustType> for IdlType {
                     }
                 },
 
-                Composite::Option => match inner1 {
+                Composite::Option => match inners.get(0).cloned() {
                     Some(inner) => {
-                        let inner_idl: IdlType = (*inner).try_into()?;
+                        let inner_idl: IdlType = inner.try_into()?;
                         IdlType::Option(Box::new(inner_idl))
                     }
                     None => {
                         anyhow::bail!("Rust Option Composite needs inner type")
                     }
                 },
-                Composite::Tuple => match (inner1, inner2) {
+                Composite::Tuple => match (inners.get(0).cloned(), inners.get(1).cloned()) {
                     // TODO(thlorenz): update once we support more than two inner tuple types
                     (Some(inner1), Some(inner2)) => {
-                        let inner1_idl: IdlType = (*inner1).try_into()?;
-                        let inner2_idl: IdlType = (*inner2).try_into()?;
+                        let inner1_idl: IdlType = inner1.try_into()?;
+                        let inner2_idl: IdlType = inner2.try_into()?;
                         IdlType::Tuple(vec![inner1_idl, inner2_idl])
                     }
                     _ => {
                         anyhow::bail!("Rust Tuple Composite needs at least two inner types")
                     }
                 },
-                Composite::HashMap => match (inner1, inner2) {
+                Composite::HashMap => match (inners.get(0).cloned(), inners.get(1).cloned()) {
                     (Some(inner1), Some(inner2)) => {
-                        let inner1_idl: IdlType = (*inner1).try_into()?;
-                        let inner2_idl: IdlType = (*inner2).try_into()?;
+                        let inner1_idl: IdlType = inner1.try_into()?;
+                        let inner2_idl: IdlType = inner2.try_into()?;
                         IdlType::HashMap(Box::new(inner1_idl), Box::new(inner2_idl))
                     }
                     _ => {
                         anyhow::bail!("Rust HashMap Composite needs two inner types")
                     }
                 },
-                Composite::BTreeMap => match (inner1, inner2) {
+                Composite::BTreeMap => match (inners.get(0).cloned(), inners.get(1).cloned()) {
                     (Some(inner1), Some(inner2)) => {
-                        let inner1_idl: IdlType = (*inner1).try_into()?;
-                        let inner2_idl: IdlType = (*inner2).try_into()?;
+                        let inner1_idl: IdlType = inner1.try_into()?;
+                        let inner2_idl: IdlType = inner2.try_into()?;
                         IdlType::BTreeMap(Box::new(inner1_idl), Box::new(inner2_idl))
                     }
                     _ => {

--- a/shank-idl/src/idl_type.rs
+++ b/shank-idl/src/idl_type.rs
@@ -3,7 +3,9 @@ use std::convert::{TryFrom, TryInto};
 use anyhow::{Error, Result};
 
 use serde::{Deserialize, Serialize};
-use shank_macro_impl::types::{Composite, Primitive, RustType, TypeKind, Value};
+use shank_macro_impl::types::{
+    Composite, Primitive, RustType, TypeKind, Value,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -95,39 +97,53 @@ impl TryFrom<RustType> for IdlType {
                         anyhow::bail!("Rust Option Composite needs inner type")
                     }
                 },
-                Composite::Tuple => match (inners.get(0).cloned(), inners.get(1).cloned()) {
-                    // TODO(thlorenz): update once we support more than two inner tuple types
-                    (Some(inner1), Some(inner2)) => {
-                        let inner1_idl: IdlType = inner1.try_into()?;
-                        let inner2_idl: IdlType = inner2.try_into()?;
-                        IdlType::Tuple(vec![inner1_idl, inner2_idl])
+                Composite::Tuple => {
+                    if inners.len() < 2 {
+                        anyhow::bail!("Rust Tuple Composite needs at least two inner types");
+                    } else {
+                        let idl_types: Result<Vec<IdlType>> =
+                            inners.into_iter().map(IdlType::try_from).collect();
+                        IdlType::Tuple(idl_types?)
                     }
-                    _ => {
-                        anyhow::bail!("Rust Tuple Composite needs at least two inner types")
+                }
+                Composite::HashMap => {
+                    match (inners.get(0).cloned(), inners.get(1).cloned()) {
+                        (Some(inner1), Some(inner2)) => {
+                            let inner1_idl: IdlType = inner1.try_into()?;
+                            let inner2_idl: IdlType = inner2.try_into()?;
+                            IdlType::HashMap(
+                                Box::new(inner1_idl),
+                                Box::new(inner2_idl),
+                            )
+                        }
+                        _ => {
+                            anyhow::bail!(
+                                "Rust HashMap Composite needs two inner types"
+                            )
+                        }
                     }
-                },
-                Composite::HashMap => match (inners.get(0).cloned(), inners.get(1).cloned()) {
-                    (Some(inner1), Some(inner2)) => {
-                        let inner1_idl: IdlType = inner1.try_into()?;
-                        let inner2_idl: IdlType = inner2.try_into()?;
-                        IdlType::HashMap(Box::new(inner1_idl), Box::new(inner2_idl))
+                }
+                Composite::BTreeMap => {
+                    match (inners.get(0).cloned(), inners.get(1).cloned()) {
+                        (Some(inner1), Some(inner2)) => {
+                            let inner1_idl: IdlType = inner1.try_into()?;
+                            let inner2_idl: IdlType = inner2.try_into()?;
+                            IdlType::BTreeMap(
+                                Box::new(inner1_idl),
+                                Box::new(inner2_idl),
+                            )
+                        }
+                        _ => {
+                            anyhow::bail!(
+                                "Rust BTreeMap Composite needs two inner types"
+                            )
+                        }
                     }
-                    _ => {
-                        anyhow::bail!("Rust HashMap Composite needs two inner types")
-                    }
-                },
-                Composite::BTreeMap => match (inners.get(0).cloned(), inners.get(1).cloned()) {
-                    (Some(inner1), Some(inner2)) => {
-                        let inner1_idl: IdlType = inner1.try_into()?;
-                        let inner2_idl: IdlType = inner2.try_into()?;
-                        IdlType::BTreeMap(Box::new(inner1_idl), Box::new(inner2_idl))
-                    }
-                    _ => {
-                        anyhow::bail!("Rust BTreeMap Composite needs two inner types")
-                    }
-                },
+                }
                 Composite::Custom(_) => {
-                    anyhow::bail!("Rust Custom Composite IDL type not yet supported")
+                    anyhow::bail!(
+                        "Rust Custom Composite IDL type not yet supported"
+                    )
                 }
             },
             TypeKind::Unit => anyhow::bail!("IDL types cannot be Unit ()"),
@@ -153,7 +169,8 @@ mod tests {
             (Primitive::USize, IdlType::U64),
         ] {
             let rust_ty = RustType::owned_primitive("prim", rust_prim);
-            let idl_ty: IdlType = rust_ty.try_into().expect("Failed to convert");
+            let idl_ty: IdlType =
+                rust_ty.try_into().expect("Failed to convert");
             assert_eq!(idl_ty, idl_expected);
         }
     }
@@ -194,7 +211,8 @@ mod tests {
 
     #[test]
     fn idl_from_rust_type_array_u8() {
-        let rust_ty = RustType::owned_array_primitive("bytes", Primitive::U8, 5);
+        let rust_ty =
+            RustType::owned_array_primitive("bytes", Primitive::U8, 5);
         let idl_ty: IdlType = rust_ty.try_into().expect("Failed to convert");
         assert_eq!(idl_ty, IdlType::Array(Box::new(IdlType::U8), 5));
     }

--- a/shank-idl/tests/fixtures/types/valid_multiple_tuples.json
+++ b/shank-idl/tests/fixtures/types/valid_multiple_tuples.json
@@ -1,0 +1,75 @@
+{
+  "version": "",
+  "name": "",
+  "instructions": [],
+  "types": [
+    {
+      "name": "TwoElementTuples",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "u8U8",
+            "type": {
+              "tuple": ["u8", "u8"]
+            }
+          },
+          {
+            "name": "u8U16",
+            "type": {
+              "tuple": ["u8", "u16"]
+            }
+          },
+          {
+            "name": "stringCustom",
+            "type": {
+              "tuple": [
+                "string",
+                {
+                  "defined": "Custom"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "NestedTwoElementTuples",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vecU8U8",
+            "type": {
+              "vec": {
+                "tuple": ["u8", "u8"]
+              }
+            }
+          },
+          {
+            "name": "hashMapU8U16StringCustom",
+            "type": {
+              "hashMap": [
+                {
+                  "tuple": ["u8", "u16"]
+                },
+                {
+                  "tuple": [
+                    "string",
+                    {
+                      "defined": "Custom"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "metadata": {
+    "origin": "shank"
+  }
+}

--- a/shank-idl/tests/fixtures/types/valid_multiple_tuples.json
+++ b/shank-idl/tests/fixtures/types/valid_multiple_tuples.json
@@ -67,6 +67,80 @@
           }
         ]
       }
+    },
+    {
+      "name": "MoreElementTuples",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "u8U8U8",
+            "type": {
+              "tuple": ["u8", "u8", "u8"]
+            }
+          },
+          {
+            "name": "u8U16I32Bool",
+            "type": {
+              "tuple": ["u8", "u16", "i32", "bool"]
+            }
+          },
+          {
+            "name": "stringCustomOptionI128U8U16U32U64",
+            "type": {
+              "tuple": [
+                "string",
+                {
+                  "defined": "Custom"
+                },
+                {
+                  "option": "i128"
+                },
+                "u8",
+                "u16",
+                "u32",
+                "u64"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "NestedMultiElementTuples",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vecU8U8U16U16U32Uy32",
+            "type": {
+              "vec": {
+                "tuple": ["u8", "u8", "u16", "u16", "u32", "u32"]
+              }
+            }
+          },
+          {
+            "name": "hashMapU8U16U32StringCustomU8U8",
+            "type": {
+              "hashMap": [
+                {
+                  "tuple": ["u8", "u16", "u32"]
+                },
+                {
+                  "tuple": [
+                    "string",
+                    {
+                      "defined": "Custom"
+                    },
+                    "u8",
+                    "u8"
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
     }
   ],
   "metadata": {

--- a/shank-idl/tests/fixtures/types/valid_multiple_tuples.rs
+++ b/shank-idl/tests/fixtures/types/valid_multiple_tuples.rs
@@ -1,0 +1,12 @@
+#[derive(BorshSerialize)]
+pub struct TwoElementTuples {
+    pub u8_u8: (u8, u8),
+    pub u8_u16: (u8, u16),
+    pub string_custom: (String, Custom),
+}
+
+#[derive(BorshSerialize)]
+pub struct NestedTwoElementTuples {
+    pub vec_u8_u8: Vec<(u8, u8)>,
+    pub hash_map_u8_u16_string_custom: HashMap<(u8, u16), (String, Custom)>,
+}

--- a/shank-idl/tests/fixtures/types/valid_multiple_tuples.rs
+++ b/shank-idl/tests/fixtures/types/valid_multiple_tuples.rs
@@ -10,3 +10,18 @@ pub struct NestedTwoElementTuples {
     pub vec_u8_u8: Vec<(u8, u8)>,
     pub hash_map_u8_u16_string_custom: HashMap<(u8, u16), (String, Custom)>,
 }
+
+#[derive(BorshSerialize)]
+pub struct MoreElementTuples {
+    pub u8_u8_u8: (u8, u8, u8),
+    pub u8_u16_i32_bool: (u8, u16, i32, bool),
+    pub string_custom_option_i128_u8_u16_u32_u64:
+        (String, Custom, Option<i128>, u8, u16, u32, u64),
+}
+
+#[derive(BorshSerialize)]
+pub struct NestedMultiElementTuples {
+    pub vec_u8_u8_u16_u16_u32_uy32: Vec<(u8, u8, u16, u16, u32, u32)>,
+    pub hash_map_u8_u16_u32_string_custom_u8_u8:
+        HashMap<(u8, u16, u32), (String, Custom, u8, u8)>,
+}

--- a/shank-idl/tests/types.rs
+++ b/shank-idl/tests/types.rs
@@ -91,3 +91,19 @@ fn type_valid_maps() {
 
     assert_eq!(idl, expected_idl);
 }
+
+#[test]
+fn type_valid_tuples() {
+    let file = fixtures_dir().join("valid_multiple_tuples.rs");
+    let idl = parse_file(&file, &ParseIdlConfig::optional_program_address())
+        .expect("Parsing should not fail")
+        .expect("File contains IDL");
+    // eprintln!("{}", serde_json::to_string_pretty(&idl).unwrap());
+
+    let expected_idl: Idl = serde_json::from_str(include_str!(
+        "./fixtures/types/valid_multiple_tuples.json"
+    ))
+    .unwrap();
+
+    assert_eq!(idl, expected_idl);
+}

--- a/shank-macro-impl/src/parsed_struct/parsed_struct_test.rs
+++ b/shank-macro-impl/src/parsed_struct/parsed_struct_test.rs
@@ -244,3 +244,17 @@ mod account_with_padding_examples {
         );
     }
 }
+
+mod account_tuples_examples {
+    use super::*;
+
+    #[test]
+    fn vec_tuple() {
+        let res = parse(quote! {
+            pub struct AccountWithTuples {
+                pub two_u8s: Vec<(u8, u8)>,
+            }
+        });
+        eprintln!("{:#?}", res);
+    }
+}

--- a/shank-macro-impl/src/parsed_struct/parsed_struct_test.rs
+++ b/shank-macro-impl/src/parsed_struct/parsed_struct_test.rs
@@ -247,6 +247,19 @@ mod account_with_padding_examples {
 
 mod account_tuples_examples {
     use super::*;
+    // TODO(thlorenz): these tests don't assert anything yet but would have to change once we
+    // support more than just two element tuples, therefore they serve purely as debugging tool for
+    // now
+
+    #[test]
+    fn tuple() {
+        let res = parse(quote! {
+            pub struct AccountWithTuples {
+                pub two_u8s: (u8, u8),
+            }
+        });
+        eprintln!("{:#?}", res);
+    }
 
     #[test]
     fn vec_tuple() {

--- a/shank-macro-impl/src/parsed_struct/parsed_struct_test.rs
+++ b/shank-macro-impl/src/parsed_struct/parsed_struct_test.rs
@@ -1,13 +1,11 @@
-use std::{collections::HashSet, ops::Deref};
+use std::collections::HashSet;
 
 use proc_macro2::TokenStream;
 use quote::quote;
 
 use crate::types::{Composite, TypeKind};
 
-use super::{
-    parse_struct, struct_field_attr::StructFieldAttr, ParsedStruct, StructField,
-};
+use super::{parse_struct, struct_field_attr::StructFieldAttr, ParsedStruct, StructField};
 use assert_matches::assert_matches;
 
 fn parse(input: TokenStream) -> ParsedStruct {
@@ -31,17 +29,12 @@ fn match_vec_field(field: &StructField, field_ident: &str, inner_ty: &str) {
     });
 }
 
-fn match_array_field(
-    field: &StructField,
-    field_ident: &str,
-    inner_ty: &str,
-    size: usize,
-) {
+fn match_array_field(field: &StructField, field_ident: &str, inner_ty: &str, size: usize) {
     assert_matches!(field, StructField { ident, rust_type, .. } => {
         assert_eq!(ident, field_ident);
         assert_eq!(rust_type.ident, "Array");
-        assert_matches!(&rust_type.kind, TypeKind::Composite(Composite::Array(array_size), inner, _)  => {
-            let inner_rust_ty = inner.as_ref().expect("array should have inner type").deref();
+        assert_matches!(&rust_type.kind, TypeKind::Composite(Composite::Array(array_size), inner)  => {
+            let inner_rust_ty = inner.get(0).expect("array should have inner type");
             assert_eq!(inner_rust_ty.ident, inner_ty, "inner array type");
             assert_eq!(*array_size, size, "array size");
         });
@@ -58,8 +51,8 @@ fn match_array_field_with_attrs(
     assert_matches!(field, StructField { ident, rust_type, attrs } => {
         assert_eq!(ident, field_ident);
         assert_eq!(rust_type.ident, "Array");
-        assert_matches!(&rust_type.kind, TypeKind::Composite(Composite::Array(array_size), inner, _)  => {
-            let inner_rust_ty = inner.as_ref().expect("array should have inner type").deref();
+        assert_matches!(&rust_type.kind, TypeKind::Composite(Composite::Array(array_size), inner)  => {
+            let inner_rust_ty = inner.get(0).expect("array should have inner type");
             assert_eq!(inner_rust_ty.ident, inner_ty, "inner array type");
             assert_eq!(*array_size, size, "array size");
         });
@@ -94,11 +87,7 @@ mod accounts_mpl_examples_auction_house {
         assert_eq!(res.ident.to_string(), "AuctionHouse");
         match_field(&res.fields[0], "auction_house_fee_account", "Pubkey");
         match_field(&res.fields[1], "auction_house_treasury", "Pubkey");
-        match_field(
-            &res.fields[2],
-            "treasury_withdrawal_destination",
-            "Pubkey",
-        );
+        match_field(&res.fields[2], "treasury_withdrawal_destination", "Pubkey");
         match_field(&res.fields[3], "fee_withdrawal_destination", "Pubkey");
         match_field(&res.fields[4], "treasury_mint", "Pubkey");
         match_field(&res.fields[5], "authority", "Pubkey");

--- a/shank-macro-impl/src/types/resolve_rust_ty.rs
+++ b/shank-macro-impl/src/types/resolve_rust_ty.rs
@@ -2,9 +2,8 @@ use std::{convert::TryFrom, ops::Deref};
 
 use quote::format_ident;
 use syn::{
-    spanned::Spanned, AngleBracketedGenericArguments, Expr, ExprLit,
-    GenericArgument, Ident, Lit, Path, PathArguments, PathSegment, Type,
-    TypeArray, TypePath, TypeTuple,
+    spanned::Spanned, AngleBracketedGenericArguments, Expr, ExprLit, GenericArgument, Ident, Lit,
+    Path, PathArguments, PathSegment, Type, TypeArray, TypePath, TypeTuple,
 };
 
 use super::{Composite, ParsedReference, Primitive, TypeKind, Value};
@@ -51,34 +50,21 @@ impl RustType {
             context: RustTypeContext::Default,
         }
     }
-    pub fn owned_primitive<T: Into<IdentWrap>>(
-        ident: T,
-        primitive: Primitive,
-    ) -> Self {
+    pub fn owned_primitive<T: Into<IdentWrap>>(ident: T, primitive: Primitive) -> Self {
         RustType::owned(ident, TypeKind::Primitive(primitive))
     }
     pub fn owned_string<T: Into<IdentWrap>>(ident: T) -> Self {
         RustType::owned(ident, TypeKind::Value(Value::String))
     }
-    pub fn owned_custom_value<T: Into<IdentWrap>>(
-        ident: T,
-        value: &str,
-    ) -> Self {
-        RustType::owned(
-            ident,
-            TypeKind::Value(Value::Custom(value.to_string())),
-        )
+    pub fn owned_custom_value<T: Into<IdentWrap>>(ident: T, value: &str) -> Self {
+        RustType::owned(ident, TypeKind::Value(Value::Custom(value.to_string())))
     }
-    pub fn owned_vec_primitive<T: Into<IdentWrap>>(
-        ident: T,
-        primitive: Primitive,
-    ) -> Self {
+    pub fn owned_vec_primitive<T: Into<IdentWrap>>(ident: T, primitive: Primitive) -> Self {
         RustType::owned(
             ident,
             TypeKind::Composite(
                 Composite::Vec,
-                Some(Box::new(RustType::owned_primitive("inner", primitive))),
-                None,
+                vec![RustType::owned_primitive("inner", primitive)],
             ),
         )
     }
@@ -92,22 +78,17 @@ impl RustType {
             ident,
             TypeKind::Composite(
                 Composite::Array(size),
-                Some(Box::new(RustType::owned_primitive("inner", primitive))),
-                None,
+                vec![RustType::owned_primitive("inner", primitive)],
             ),
         )
     }
 
-    pub fn owned_option_primitive<T: Into<IdentWrap>>(
-        ident: T,
-        primitive: Primitive,
-    ) -> Self {
+    pub fn owned_option_primitive<T: Into<IdentWrap>>(ident: T, primitive: Primitive) -> Self {
         RustType::owned(
             ident,
             TypeKind::Composite(
                 Composite::Option,
-                Some(Box::new(RustType::owned_primitive("inner", primitive))),
-                None,
+                vec![RustType::owned_primitive("inner", primitive)],
             ),
         )
     }
@@ -152,18 +133,13 @@ fn len_from_expr(expr: &Expr) -> ParseResult<usize> {
     }
 }
 
-pub fn resolve_rust_ty(
-    ty: &Type,
-    context: RustTypeContext,
-) -> ParseResult<RustType> {
+pub fn resolve_rust_ty(ty: &Type, context: RustTypeContext) -> ParseResult<RustType> {
     let (ty, reference) = match ty {
         Type::Reference(r) => {
             let pr = ParsedReference::from(r);
             (r.elem.as_ref(), pr)
         }
-        Type::Array(_) | Type::Path(_) | Type::Tuple(_) => {
-            (ty, ParsedReference::Owned)
-        }
+        Type::Array(_) | Type::Path(_) | Type::Tuple(_) => (ty, ParsedReference::Owned),
         ty => {
             eprintln!("{:#?}", ty);
             return Err(ParseError::new(
@@ -180,9 +156,7 @@ pub fn resolve_rust_ty(
         }
         Type::Array(TypeArray { elem, len, .. }) => {
             let (inner_ident, inner_kind) = match elem.deref() {
-                Type::Path(TypePath { path, .. }) => {
-                    ident_and_kind_from_path(path)
-                }
+                Type::Path(TypePath { path, .. }) => ident_and_kind_from_path(path),
                 _ => {
                     return Err(ParseError::new(
                         ty.span(),
@@ -197,11 +171,7 @@ pub fn resolve_rust_ty(
                 reference: ParsedReference::Owned,
                 context: RustTypeContext::CollectionItem,
             };
-            let kind = TypeKind::Composite(
-                Composite::Array(len),
-                Some(Box::new(inner_ty)),
-                None,
-            );
+            let kind = TypeKind::Composite(Composite::Array(len), vec![inner_ty]);
             (format_ident!("Array"), kind)
         }
         Type::Tuple(TypeTuple { elems, .. }) => {
@@ -230,20 +200,20 @@ pub fn resolve_rust_ty(
             // RustTypes
             assert!(types.len() <= 2, "Only supporting two item tuple for now");
 
-            let inner1 = types.get(0).ok_or_else(|| ParseError::new(
-                ty.span(),
-                "A tuple should have two inner types but is missing even the first one",
-            ))?;
-            let inner2 = types.get(1).ok_or_else(|| ParseError::new(
-                ty.span(),
-                "A tuple should have two inner types but is missing the second one",
-            ))?;
+            let inner1 = types.get(0).ok_or_else(|| {
+                ParseError::new(
+                    ty.span(),
+                    "A tuple should have two inner types but is missing even the first one",
+                )
+            })?;
+            let inner2 = types.get(1).ok_or_else(|| {
+                ParseError::new(
+                    ty.span(),
+                    "A tuple should have two inner types but is missing the second one",
+                )
+            })?;
 
-            let kind = TypeKind::Composite(
-                Composite::Tuple,
-                Some(Box::new(inner1.clone())),
-                Some(Box::new(inner2.clone())),
-            );
+            let kind = TypeKind::Composite(Composite::Tuple, vec![inner1.clone(), inner2.clone()]);
             (format_ident!("Tuple"), kind)
         }
         _ => {
@@ -297,48 +267,30 @@ fn ident_to_kind(ident: &Ident, arguments: &PathArguments) -> TypeKind {
         }
 
         // Composite Types
-        PathArguments::AngleBracketed(AngleBracketedGenericArguments {
-            args,
-            ..
-        }) => {
+        PathArguments::AngleBracketed(AngleBracketedGenericArguments { args, .. }) => {
             match args.len() {
                 // -----------------
                 // Single Type Parameter
                 // -----------------
                 1 => match &args[0] {
                     GenericArgument::Type(ty) => match ident_str.as_str() {
-                        "Vec" => {
-                            let inner = resolve_rust_ty(
-                                ty,
-                                RustTypeContext::CollectionItem,
-                            )
-                            .ok()
-                            .map(|x| Box::new(x));
-                            TypeKind::Composite(Composite::Vec, inner, None)
-                        }
-                        "Option" => {
-                            let inner = resolve_rust_ty(
-                                ty,
-                                RustTypeContext::OptionItem,
-                            )
-                            .ok()
-                            .map(|x| Box::new(x));
-                            TypeKind::Composite(Composite::Option, inner, None)
-                        }
-                        _ => {
-                            let inner = resolve_rust_ty(
-                                ty,
-                                RustTypeContext::CustomItem,
-                            )
-                            .ok()
-                            .map(|x| Box::new(x));
-
-                            TypeKind::Composite(
+                        "Vec" => match resolve_rust_ty(ty, RustTypeContext::CollectionItem) {
+                            Ok(inner) => TypeKind::Composite(Composite::Vec, vec![inner]),
+                            Err(_) => TypeKind::Composite(Composite::Vec, vec![]),
+                        },
+                        "Option" => match resolve_rust_ty(ty, RustTypeContext::OptionItem) {
+                            Ok(inner) => TypeKind::Composite(Composite::Option, vec![inner]),
+                            Err(_) => TypeKind::Composite(Composite::Option, vec![]),
+                        },
+                        _ => match resolve_rust_ty(ty, RustTypeContext::CustomItem) {
+                            Ok(inner) => TypeKind::Composite(
                                 Composite::Custom(ident_str.clone()),
-                                inner,
-                                None,
-                            )
-                        }
+                                vec![inner],
+                            ),
+                            Err(_) => {
+                                TypeKind::Composite(Composite::Custom(ident_str.clone()), vec![])
+                            }
+                        },
                     },
                     _ => TypeKind::Unknown,
                 },
@@ -346,39 +298,35 @@ fn ident_to_kind(ident: &Ident, arguments: &PathArguments) -> TypeKind {
                 // Two Type Parameters
                 // -----------------
                 2 => match (&args[0], &args[1]) {
-                    (
-                        GenericArgument::Type(ty1),
-                        GenericArgument::Type(ty2),
-                    ) => match ident_str.as_str() {
-                        ident if ident == "HashMap" || ident == "BTreeMap" => {
-                            let inner1 = resolve_rust_ty(
-                                ty1,
-                                RustTypeContext::CollectionItem,
-                            )
-                            .ok()
-                            .map(|x| Box::new(x));
-                            let inner2 = resolve_rust_ty(
-                                ty2,
-                                RustTypeContext::CollectionItem,
-                            )
-                            .ok()
-                            .map(|x| Box::new(x));
+                    (GenericArgument::Type(ty1), GenericArgument::Type(ty2)) => {
+                        match ident_str.as_str() {
+                            ident if ident == "HashMap" || ident == "BTreeMap" => {
+                                let inners = match (
+                                    resolve_rust_ty(ty1, RustTypeContext::CollectionItem),
+                                    resolve_rust_ty(ty2, RustTypeContext::CollectionItem),
+                                ) {
+                                    (Ok(inner1), Ok(inner2)) => vec![inner1, inner2],
+                                    (Ok(inner1), Err(_)) => vec![inner1],
+                                    (Err(_), Ok(inner2)) => vec![inner2],
+                                    (Err(_), Err(_)) => vec![],
+                                };
 
-                            let composite = if ident == "HashMap" {
-                                Composite::HashMap
-                            } else {
-                                Composite::BTreeMap
-                            };
-                            TypeKind::Composite(composite, inner1, inner2)
-                        }
-                        _ => {
-                            eprintln!("ident: {:#?}, args: {:#?}", ident, args);
-                            todo!(
+                                let composite = if ident == "HashMap" {
+                                    Composite::HashMap
+                                } else {
+                                    Composite::BTreeMap
+                                };
+                                TypeKind::Composite(composite, inners)
+                            }
+                            _ => {
+                                eprintln!("ident: {:#?}, args: {:#?}", ident, args);
+                                todo!(
                                 "Not yet handling custom angle bracketed types with {} type parameters",
                                 args.len()
                             )
+                            }
                         }
-                    },
+                    }
                     _ => TypeKind::Unknown,
                 },
                 _ => {

--- a/shank-macro-impl/src/types/resolve_rust_ty.rs
+++ b/shank-macro-impl/src/types/resolve_rust_ty.rs
@@ -175,6 +175,13 @@ pub fn resolve_rust_ty(ty: &Type, context: RustTypeContext) -> ParseResult<RustT
             (format_ident!("Array"), kind)
         }
         Type::Tuple(TypeTuple { elems, .. }) => {
+            if elems.len() < 2 {
+                return Err(ParseError::new(
+                    ty.span(),
+                    "A Tuple should have at least 2 type parameters",
+                ));
+            }
+
             let mut types: Vec<RustType> = vec![];
             for elem in elems {
                 match elem {
@@ -196,24 +203,7 @@ pub fn resolve_rust_ty(ty: &Type, context: RustTypeContext) -> ParseResult<RustT
                     }
                 }
             }
-            // TODO(thlorenz): Need to modify Composite everywhere to allow more than 2 inner
-            // RustTypes
-            assert!(types.len() <= 2, "Only supporting two item tuple for now");
-
-            let inner1 = types.get(0).ok_or_else(|| {
-                ParseError::new(
-                    ty.span(),
-                    "A tuple should have two inner types but is missing even the first one",
-                )
-            })?;
-            let inner2 = types.get(1).ok_or_else(|| {
-                ParseError::new(
-                    ty.span(),
-                    "A tuple should have two inner types but is missing the second one",
-                )
-            })?;
-
-            let kind = TypeKind::Composite(Composite::Tuple, vec![inner1.clone(), inner2.clone()]);
+            let kind = TypeKind::Composite(Composite::Tuple, types);
             (format_ident!("Tuple"), kind)
         }
         _ => {

--- a/shank-macro-impl/src/types/type_kind.rs
+++ b/shank-macro-impl/src/types/type_kind.rs
@@ -285,6 +285,7 @@ impl Value {
 pub enum Composite {
     Vec,
     Array(usize),
+    Tuple,
     Option,
     HashMap,
     BTreeMap,
@@ -296,6 +297,7 @@ impl Debug for Composite {
         match self {
             Composite::Vec => write!(f, "Composite::Vec"),
             Composite::Array(size) => write!(f, "Composite::Array({})", size),
+            Composite::Tuple => write!(f, "Composite::Tuple"),
             Composite::Option => write!(f, "Composite::Option"),
             Composite::HashMap => write!(f, "Composite::HashMap"),
             Composite::BTreeMap => write!(f, "Composite::BTreeMap"),


### PR DESCRIPTION
## Summary

This adds support to parse out top level tuples of varying sizes and nested tuples as well.
The resulting IDL type `"tuple"` has an array for the inner tuple types.

### Changes to Composites

Until now `Composite` types assumed 1- 2 inner types, i.e. for `Vec`s and `HashMap`s.
However for `Tuple`s there can be an arbitrary amount of inner types `>= 2`. Thus inner types
in `Composite`s are now stored in a `Vec` of arbitrary size.

## Examples

### Top Level Tuple

```rs
pub u8_u8: (u8, u8),
```

```json
{
  "name": "u8U8",
  "type": {
    "tuple": ["u8", "u8"]
  }
}
```

### Nested Tuple

```rs
pub hash_map_u8_u16_string_custom: HashMap<(u8, u16), (String, Custom)>,
```

```json
{
  "name": "hashMapU8U16StringCustom",
  "type": {
    "hashMap": [
      {
        "tuple": ["u8", "u16"]
      },
      {
        "tuple": [
          "string",
          {
            "defined": "Custom"
          }
        ]
      }
    ]
  }
}
```

### Multi Inner Type Tuple

```rs
pub string_custom_option_i128_u8_u16_u32_u64:
    (String, Custom, Option<i128>, u8, u16, u32, u64),
```

```json
{
  "name": "stringCustomOptionI128U8U16U32U64",
  "type": {
    "tuple": [
      "string",
      {
        "defined": "Custom"
      },
      {
        "option": "i128"
      },
      "u8",
      "u16",
      "u32",
      "u64"
    ]
  }
}
```
