### PR TITLE
Extend shank instructions to work with Instruction struct variants

### DIFF
--- a/shank-idl/src/idl_instruction.rs
+++ b/shank-idl/src/idl_instruction.rs
@@ -4,8 +4,7 @@ use anyhow::{anyhow, ensure, Error, Result};
 use heck::MixedCase;
 use serde::{Deserialize, Serialize};
 use shank_macro_impl::instruction::{
-    Instruction, InstructionAccount, InstructionVariant,
-    InstructionVariantFields,
+    Instruction, InstructionAccount, InstructionVariant, InstructionVariantFields,
 };
 
 use crate::{idl_field::IdlField, idl_type::IdlType};
@@ -61,7 +60,6 @@ impl TryFrom<InstructionVariant> for IdlInstruction {
                 let mut parsed: Vec<IdlField> = vec![];
                 for (field_name, field_ty) in args.iter() {
                     let ty = IdlType::try_from(field_ty.clone())?;
-                    println!("\t{}: {:?}", &field_name.to_mixed_case(), ty);
                     parsed.push(IdlField {
                         name: field_name.to_mixed_case(),
                         ty,

--- a/shank-idl/src/idl_instruction.rs
+++ b/shank-idl/src/idl_instruction.rs
@@ -4,7 +4,8 @@ use anyhow::{anyhow, ensure, Error, Result};
 use heck::MixedCase;
 use serde::{Deserialize, Serialize};
 use shank_macro_impl::instruction::{
-    Instruction, InstructionAccount, InstructionVariant, InstructionVariantFields,
+    Instruction, InstructionAccount, InstructionVariant,
+    InstructionVariantFields,
 };
 
 use crate::{idl_field::IdlField, idl_type::IdlType};
@@ -75,10 +76,10 @@ impl TryFrom<InstructionVariant> for IdlInstruction {
                         if field_ty.kind.is_custom() {
                             field_ty.ident.to_string().to_mixed_case()
                         } else {
-                            "instructionArgs".to_string()
+                            "args".to_string()
                         }
                     } else {
-                        format!("instructionArgs{}", index).to_string()
+                        format!("arg{}", index).to_string()
                     };
                     let ty = IdlType::try_from(field_ty.clone())?;
                     parsed.push(IdlField {

--- a/shank-idl/src/idl_instruction.rs
+++ b/shank-idl/src/idl_instruction.rs
@@ -5,6 +5,7 @@ use heck::MixedCase;
 use serde::{Deserialize, Serialize};
 use shank_macro_impl::instruction::{
     Instruction, InstructionAccount, InstructionVariant,
+    InstructionVariantFields,
 };
 
 use crate::{idl_field::IdlField, idl_type::IdlType};
@@ -49,27 +50,49 @@ impl TryFrom<InstructionVariant> for IdlInstruction {
     fn try_from(variant: InstructionVariant) -> Result<Self> {
         let InstructionVariant {
             ident,
-            field_ty,
+            field_tys,
             accounts,
             discriminant,
         } = variant;
 
         let name = ident.to_string();
-        let args: Vec<IdlField> = if let Some(field_ty) = field_ty {
-            let name = if field_ty.kind.is_custom() {
-                field_ty.ident.to_string().to_mixed_case()
-            } else {
-                "instructionArgs".to_string()
-            };
-            let ty = IdlType::try_from(field_ty)?;
-            vec![IdlField {
-                name,
-                ty,
-                attrs: None,
-            }]
-        } else {
-            vec![]
+        let parsed_idl_fields: Result<Vec<IdlField>, Error> = match field_tys {
+            InstructionVariantFields::Named(args) => {
+                let mut parsed: Vec<IdlField> = vec![];
+                for (field_name, field_ty) in args.iter() {
+                    let ty = IdlType::try_from(field_ty.clone())?;
+                    println!("\t{}: {:?}", &field_name.to_mixed_case(), ty);
+                    parsed.push(IdlField {
+                        name: field_name.to_mixed_case(),
+                        ty,
+                        attrs: None,
+                    })
+                }
+                Ok(parsed)
+            }
+            InstructionVariantFields::Unnamed(args) => {
+                let mut parsed: Vec<IdlField> = vec![];
+                for (index, field_ty) in args.iter().enumerate() {
+                    let name = if args.len() == 1 {
+                        if field_ty.kind.is_custom() {
+                            field_ty.ident.to_string().to_mixed_case()
+                        } else {
+                            "instructionArgs".to_string()
+                        }
+                    } else {
+                        format!("instructionArgs{}", index).to_string()
+                    };
+                    let ty = IdlType::try_from(field_ty.clone())?;
+                    parsed.push(IdlField {
+                        name,
+                        ty,
+                        attrs: None,
+                    })
+                }
+                Ok(parsed)
+            }
         };
+        let args: Vec<IdlField> = parsed_idl_fields?;
 
         let accounts = accounts.into_iter().map(IdlAccountItem::from).collect();
         ensure!(

--- a/shank-idl/tests/fixtures/instructions/single_file/instruction_with_args.json
+++ b/shank-idl/tests/fixtures/instructions/single_file/instruction_with_args.json
@@ -37,7 +37,7 @@
       ],
       "args": [
         {
-          "name": "instructionArgs",
+          "name": "args",
           "type": {
             "option": "u8"
           }

--- a/shank-idl/tests/fixtures/instructions/single_file/instruction_with_multiple_args.json
+++ b/shank-idl/tests/fixtures/instructions/single_file/instruction_with_multiple_args.json
@@ -13,19 +13,19 @@
       ],
       "args": [
         {
-          "name": "instructionArgs0",
+          "name": "arg0",
           "type": {
             "option": "u8"
           }
         },
         {
-          "name": "instructionArgs1",
+          "name": "arg1",
           "type": {
             "defined": "ComplexArgs"
           }
         },
         {
-          "name": "instructionArgs2",
+          "name": "arg2",
           "type": {
             "defined": "ComplexArgs"
           }

--- a/shank-idl/tests/fixtures/instructions/single_file/instruction_with_multiple_args.json
+++ b/shank-idl/tests/fixtures/instructions/single_file/instruction_with_multiple_args.json
@@ -1,0 +1,43 @@
+{
+  "version": "",
+  "name": "",
+  "instructions": [
+    {
+      "name": "CloseThing",
+      "accounts": [
+        {
+          "name": "creator",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "instructionArgs0",
+          "type": {
+            "option": "u8"
+          }
+        },
+        {
+          "name": "instructionArgs1",
+          "type": {
+            "defined": "ComplexArgs"
+          }
+        },
+        {
+          "name": "instructionArgs2",
+          "type": {
+            "defined": "ComplexArgs"
+          }
+        }
+      ],
+      "discriminant": {
+        "type": "u8",
+        "value": 0
+      }
+    }
+  ],
+  "metadata": {
+    "origin": "shank"
+  }
+}

--- a/shank-idl/tests/fixtures/instructions/single_file/instruction_with_multiple_args.rs
+++ b/shank-idl/tests/fixtures/instructions/single_file/instruction_with_multiple_args.rs
@@ -1,0 +1,5 @@
+#[derive(ShankInstruction)]
+pub enum Instruction {
+    #[account(0, name = "creator", sig)]
+    CloseThing(Option<u8>, ComplexArgs, ComplexArgs),
+}

--- a/shank-idl/tests/fixtures/instructions/single_file/instruction_with_struct_args.json
+++ b/shank-idl/tests/fixtures/instructions/single_file/instruction_with_struct_args.json
@@ -46,7 +46,7 @@
       ],
       "args": [
         {
-          "name": "instructionArgs",
+          "name": "args",
           "type": {
             "option": "u8"
           }

--- a/shank-idl/tests/fixtures/instructions/single_file/instruction_with_struct_args.json
+++ b/shank-idl/tests/fixtures/instructions/single_file/instruction_with_struct_args.json
@@ -1,0 +1,64 @@
+{
+  "version": "",
+  "name": "",
+  "instructions": [
+    {
+      "name": "CreateThing",
+      "accounts": [
+        {
+          "name": "creator",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "thing",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "someArgs",
+          "type": {
+            "defined": "SomeArgs"
+          }
+        },
+        {
+          "name": "otherArgs",
+          "type": {
+            "defined": "OtherArgs"
+          }
+        }
+      ],
+      "discriminant": {
+        "type": "u8",
+        "value": 0
+      }
+    },
+    {
+      "name": "CloseThing",
+      "accounts": [
+        {
+          "name": "creator",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "instructionArgs",
+          "type": {
+            "option": "u8"
+          }
+        }
+      ],
+      "discriminant": {
+        "type": "u8",
+        "value": 1
+      }
+    }
+  ],
+  "metadata": {
+    "origin": "shank"
+  }
+}

--- a/shank-idl/tests/fixtures/instructions/single_file/instruction_with_struct_args.rs
+++ b/shank-idl/tests/fixtures/instructions/single_file/instruction_with_struct_args.rs
@@ -1,0 +1,11 @@
+#[derive(ShankInstruction)]
+pub enum Instruction {
+    #[account(0, name = "creator", sig)]
+    #[account(1, name = "thing", mut)]
+    CreateThing {
+        some_args: SomeArgs,
+        other_args: OtherArgs,
+    },
+    #[account(0, name = "creator", sig)]
+    CloseThing(Option<u8>),
+}

--- a/shank-idl/tests/instructions.rs
+++ b/shank-idl/tests/instructions.rs
@@ -44,6 +44,40 @@ fn instruction_from_single_file_with_args() {
 }
 
 #[test]
+fn instruction_from_single_file_with_struct_args() {
+    let file = fixtures_dir()
+        .join("single_file")
+        .join("instruction_with_struct_args.rs");
+    let idl = parse_file(&file, &ParseIdlConfig::optional_program_address())
+        .expect("Parsing should not fail")
+        .expect("File contains IDL");
+
+    let expected_idl: Idl = serde_json::from_str(include_str!(
+        "./fixtures/instructions/single_file/instruction_with_struct_args.json"
+    ))
+    .unwrap();
+
+    assert_eq!(idl, expected_idl);
+}
+
+#[test]
+fn instruction_from_single_file_with_multiple_args() {
+    let file = fixtures_dir()
+        .join("single_file")
+        .join("instruction_with_multiple_args.rs");
+    let idl = parse_file(&file, &ParseIdlConfig::optional_program_address())
+        .expect("Parsing should not fail")
+        .expect("File contains IDL");
+
+    let expected_idl: Idl = serde_json::from_str(include_str!(
+        "./fixtures/instructions/single_file/instruction_with_multiple_args.json"
+    ))
+    .unwrap();
+
+    assert_eq!(idl, expected_idl);
+}
+
+#[test]
 fn instruction_from_single_file_with_optional_account() {
     let file = fixtures_dir()
         .join("single_file")

--- a/shank-macro-impl/src/instruction/instruction.rs
+++ b/shank-macro-impl/src/instruction/instruction.rs
@@ -27,8 +27,7 @@ impl Instruction {
         skip_derive_attr_check: bool,
     ) -> ParseResult<Option<Instruction>> {
         if skip_derive_attr_check
-            || get_derive_attr(&item_enum.attrs, DERIVE_INSTRUCTION_ATTR)
-                .is_some()
+            || get_derive_attr(&item_enum.attrs, DERIVE_INSTRUCTION_ATTR).is_some()
         {
             let parsed_enum = ParsedEnum::try_from(item_enum)?;
             Instruction::try_from(&parsed_enum).map(Some)
@@ -42,9 +41,7 @@ impl TryFrom<&ParsedEnum> for Option<Instruction> {
     type Error = ParseError;
 
     fn try_from(parsed_enum: &ParsedEnum) -> ParseResult<Self> {
-        match get_derive_attr(&parsed_enum.attrs, DERIVE_INSTRUCTION_ATTR)
-            .map(|_| parsed_enum)
-        {
+        match get_derive_attr(&parsed_enum.attrs, DERIVE_INSTRUCTION_ATTR).map(|_| parsed_enum) {
             Some(ix_enum) => ix_enum.try_into().map(Some),
             None => Ok(None),
         }
@@ -76,7 +73,7 @@ impl TryFrom<&ParsedEnum> for Instruction {
 #[derive(Debug)]
 pub struct InstructionVariant {
     pub ident: Ident,
-    pub field_ty: Option<RustType>,
+    pub field_tys: Vec<RustType>,
     pub accounts: Vec<InstructionAccount>,
     pub discriminant: usize,
 }
@@ -93,19 +90,19 @@ impl TryFrom<&ParsedEnumVariant> for InstructionVariant {
             ..
         } = variant;
 
-        if fields.len() > 1 {
-            return Err(ParseError::new_spanned(
-                fields.get(1).map(|x| &x.rust_type.ident),
-                "An Instruction can only have one arg field",
-            ));
-        }
-        let field_ty = fields.first().map(|x| x.rust_type.clone());
+        // if fields.len() > 1 {
+        //     return Err(ParseError::new_spanned(
+        //         fields.get(1).map(|x| &x.rust_type.ident),
+        //         "An Instruction can only have one arg field",
+        //     ));
+        // }
+        let field_tys = fields.iter().map(|x| x.rust_type.clone()).collect();
         let attrs: &[Attribute] = attrs.as_ref();
         let accounts: InstructionAccounts = attrs.try_into()?;
 
         Ok(Self {
             ident: ident.clone(),
-            field_ty,
+            field_tys,
             accounts: accounts.0,
             discriminant: *discriminant,
         })

--- a/shank-macro-impl/src/instruction/instruction_test.rs
+++ b/shank-macro-impl/src/instruction/instruction_test.rs
@@ -7,8 +7,7 @@ use crate::types::{Primitive, RustType};
 use super::instruction::{Instruction, InstructionVariant};
 
 fn parse_instruction(code: TokenStream) -> ParseResult<Option<Instruction>> {
-    let item_enum = syn::parse2::<ItemEnum>(code)
-        .expect("Should parse ItemEnum successfully");
+    let item_enum = syn::parse2::<ItemEnum>(code).expect("Should parse ItemEnum successfully");
     Instruction::try_from_item_enum(&item_enum, false)
 }
 
@@ -16,12 +15,12 @@ fn assert_instruction_variant(
     variant: &InstructionVariant,
     name: &str,
     expected_discriminant: usize,
-    expected_field_ty: Option<RustType>,
+    expected_field_tys: &Vec<RustType>,
     accounts_len: usize,
 ) {
     let InstructionVariant {
         ident,
-        field_ty,
+        field_tys,
         accounts,
         discriminant,
     } = variant;
@@ -29,7 +28,12 @@ fn assert_instruction_variant(
     assert_eq!(ident.to_string(), name);
     assert_eq!(discriminant, &expected_discriminant, "discriminant");
     assert_eq!(accounts.len(), accounts_len, "accounts");
-    assert_eq!(field_ty, &expected_field_ty, "field type");
+    assert_eq!(field_tys.len(), expected_field_tys.len(), "fields size");
+    for field_idx in 0..expected_field_tys.len() {
+        let field_ty = field_tys.get(field_idx).unwrap();
+        let expected_field_ty = expected_field_tys.get(field_idx).unwrap();
+        assert_eq!(field_ty, expected_field_ty, "field type");
+    }
 }
 
 #[test]
@@ -62,8 +66,8 @@ fn parse_c_style_instruction() {
         "non-optional account of second variant"
     );
 
-    assert_instruction_variant(&parsed.variants[0], "CreateThing", 0, None, 2);
-    assert_instruction_variant(&parsed.variants[1], "CloseThing", 1, None, 1);
+    assert_instruction_variant(&parsed.variants[0], "CreateThing", 0, &vec![], 2);
+    assert_instruction_variant(&parsed.variants[1], "CloseThing", 1, &vec![], 1);
 }
 
 #[test]
@@ -82,12 +86,12 @@ fn parse_custom_field_variant_instruction() {
     assert_eq!(parsed.ident.to_string(), "Instruction", "enum ident");
     assert_eq!(parsed.variants.len(), 2, "variants");
 
-    assert_instruction_variant(&parsed.variants[0], "CreateThing", 0, None, 0);
+    assert_instruction_variant(&parsed.variants[0], "CreateThing", 0, &vec![], 0);
     assert_instruction_variant(
         &parsed.variants[1],
         "CloseThing",
         1,
-        Some(RustType::owned_custom_value("CloseArgs", "CloseArgs")),
+        &vec![RustType::owned_custom_value("CloseArgs", "CloseArgs")],
         1,
     );
 }
@@ -109,12 +113,12 @@ fn parse_u8_field_variant_instruction() {
     assert_eq!(parsed.ident.to_string(), "Instruction", "enum ident");
     assert_eq!(parsed.variants.len(), 2, "variants");
 
-    assert_instruction_variant(&parsed.variants[0], "CreateThing", 0, None, 1);
+    assert_instruction_variant(&parsed.variants[0], "CreateThing", 0, &vec![], 1);
     assert_instruction_variant(
         &parsed.variants[1],
         "CloseThing",
         1,
-        Some(RustType::owned_primitive("u8", Primitive::U8)),
+        &vec![RustType::owned_primitive("u8", Primitive::U8)],
         1,
     );
 }

--- a/shank-macro-impl/src/types/resolve_rust_ty.rs
+++ b/shank-macro-impl/src/types/resolve_rust_ty.rs
@@ -2,8 +2,9 @@ use std::{convert::TryFrom, ops::Deref};
 
 use quote::format_ident;
 use syn::{
-    spanned::Spanned, AngleBracketedGenericArguments, Expr, ExprLit, GenericArgument, Ident, Lit,
-    Path, PathArguments, PathSegment, Type, TypeArray, TypePath, TypeTuple,
+    spanned::Spanned, AngleBracketedGenericArguments, Expr, ExprLit,
+    GenericArgument, Ident, Lit, Path, PathArguments, PathSegment, Type,
+    TypeArray, TypePath, TypeTuple,
 };
 
 use super::{Composite, ParsedReference, Primitive, TypeKind, Value};
@@ -50,16 +51,28 @@ impl RustType {
             context: RustTypeContext::Default,
         }
     }
-    pub fn owned_primitive<T: Into<IdentWrap>>(ident: T, primitive: Primitive) -> Self {
+    pub fn owned_primitive<T: Into<IdentWrap>>(
+        ident: T,
+        primitive: Primitive,
+    ) -> Self {
         RustType::owned(ident, TypeKind::Primitive(primitive))
     }
     pub fn owned_string<T: Into<IdentWrap>>(ident: T) -> Self {
         RustType::owned(ident, TypeKind::Value(Value::String))
     }
-    pub fn owned_custom_value<T: Into<IdentWrap>>(ident: T, value: &str) -> Self {
-        RustType::owned(ident, TypeKind::Value(Value::Custom(value.to_string())))
+    pub fn owned_custom_value<T: Into<IdentWrap>>(
+        ident: T,
+        value: &str,
+    ) -> Self {
+        RustType::owned(
+            ident,
+            TypeKind::Value(Value::Custom(value.to_string())),
+        )
     }
-    pub fn owned_vec_primitive<T: Into<IdentWrap>>(ident: T, primitive: Primitive) -> Self {
+    pub fn owned_vec_primitive<T: Into<IdentWrap>>(
+        ident: T,
+        primitive: Primitive,
+    ) -> Self {
         RustType::owned(
             ident,
             TypeKind::Composite(
@@ -83,7 +96,10 @@ impl RustType {
         )
     }
 
-    pub fn owned_option_primitive<T: Into<IdentWrap>>(ident: T, primitive: Primitive) -> Self {
+    pub fn owned_option_primitive<T: Into<IdentWrap>>(
+        ident: T,
+        primitive: Primitive,
+    ) -> Self {
         RustType::owned(
             ident,
             TypeKind::Composite(
@@ -133,13 +149,18 @@ fn len_from_expr(expr: &Expr) -> ParseResult<usize> {
     }
 }
 
-pub fn resolve_rust_ty(ty: &Type, context: RustTypeContext) -> ParseResult<RustType> {
+pub fn resolve_rust_ty(
+    ty: &Type,
+    context: RustTypeContext,
+) -> ParseResult<RustType> {
     let (ty, reference) = match ty {
         Type::Reference(r) => {
             let pr = ParsedReference::from(r);
             (r.elem.as_ref(), pr)
         }
-        Type::Array(_) | Type::Path(_) | Type::Tuple(_) => (ty, ParsedReference::Owned),
+        Type::Array(_) | Type::Path(_) | Type::Tuple(_) => {
+            (ty, ParsedReference::Owned)
+        }
         ty => {
             eprintln!("{:#?}", ty);
             return Err(ParseError::new(
@@ -156,7 +177,9 @@ pub fn resolve_rust_ty(ty: &Type, context: RustTypeContext) -> ParseResult<RustT
         }
         Type::Array(TypeArray { elem, len, .. }) => {
             let (inner_ident, inner_kind) = match elem.deref() {
-                Type::Path(TypePath { path, .. }) => ident_and_kind_from_path(path),
+                Type::Path(TypePath { path, .. }) => {
+                    ident_and_kind_from_path(path)
+                }
                 _ => {
                     return Err(ParseError::new(
                         ty.span(),
@@ -171,7 +194,8 @@ pub fn resolve_rust_ty(ty: &Type, context: RustTypeContext) -> ParseResult<RustT
                 reference: ParsedReference::Owned,
                 context: RustTypeContext::CollectionItem,
             };
-            let kind = TypeKind::Composite(Composite::Array(len), vec![inner_ty]);
+            let kind =
+                TypeKind::Composite(Composite::Array(len), vec![inner_ty]);
             (format_ident!("Array"), kind)
         }
         Type::Tuple(TypeTuple { elems, .. }) => {
@@ -257,29 +281,51 @@ fn ident_to_kind(ident: &Ident, arguments: &PathArguments) -> TypeKind {
         }
 
         // Composite Types
-        PathArguments::AngleBracketed(AngleBracketedGenericArguments { args, .. }) => {
+        PathArguments::AngleBracketed(AngleBracketedGenericArguments {
+            args,
+            ..
+        }) => {
             match args.len() {
                 // -----------------
                 // Single Type Parameter
                 // -----------------
                 1 => match &args[0] {
                     GenericArgument::Type(ty) => match ident_str.as_str() {
-                        "Vec" => match resolve_rust_ty(ty, RustTypeContext::CollectionItem) {
-                            Ok(inner) => TypeKind::Composite(Composite::Vec, vec![inner]),
-                            Err(_) => TypeKind::Composite(Composite::Vec, vec![]),
+                        "Vec" => match resolve_rust_ty(
+                            ty,
+                            RustTypeContext::CollectionItem,
+                        ) {
+                            Ok(inner) => {
+                                TypeKind::Composite(Composite::Vec, vec![inner])
+                            }
+                            Err(_) => {
+                                TypeKind::Composite(Composite::Vec, vec![])
+                            }
                         },
-                        "Option" => match resolve_rust_ty(ty, RustTypeContext::OptionItem) {
-                            Ok(inner) => TypeKind::Composite(Composite::Option, vec![inner]),
-                            Err(_) => TypeKind::Composite(Composite::Option, vec![]),
+                        "Option" => match resolve_rust_ty(
+                            ty,
+                            RustTypeContext::OptionItem,
+                        ) {
+                            Ok(inner) => TypeKind::Composite(
+                                Composite::Option,
+                                vec![inner],
+                            ),
+                            Err(_) => {
+                                TypeKind::Composite(Composite::Option, vec![])
+                            }
                         },
-                        _ => match resolve_rust_ty(ty, RustTypeContext::CustomItem) {
+                        _ => match resolve_rust_ty(
+                            ty,
+                            RustTypeContext::CustomItem,
+                        ) {
                             Ok(inner) => TypeKind::Composite(
                                 Composite::Custom(ident_str.clone()),
                                 vec![inner],
                             ),
-                            Err(_) => {
-                                TypeKind::Composite(Composite::Custom(ident_str.clone()), vec![])
-                            }
+                            Err(_) => TypeKind::Composite(
+                                Composite::Custom(ident_str.clone()),
+                                vec![],
+                            ),
                         },
                     },
                     _ => TypeKind::Unknown,
@@ -288,35 +334,44 @@ fn ident_to_kind(ident: &Ident, arguments: &PathArguments) -> TypeKind {
                 // Two Type Parameters
                 // -----------------
                 2 => match (&args[0], &args[1]) {
-                    (GenericArgument::Type(ty1), GenericArgument::Type(ty2)) => {
-                        match ident_str.as_str() {
-                            ident if ident == "HashMap" || ident == "BTreeMap" => {
-                                let inners = match (
-                                    resolve_rust_ty(ty1, RustTypeContext::CollectionItem),
-                                    resolve_rust_ty(ty2, RustTypeContext::CollectionItem),
-                                ) {
-                                    (Ok(inner1), Ok(inner2)) => vec![inner1, inner2],
-                                    (Ok(inner1), Err(_)) => vec![inner1],
-                                    (Err(_), Ok(inner2)) => vec![inner2],
-                                    (Err(_), Err(_)) => vec![],
-                                };
+                    (
+                        GenericArgument::Type(ty1),
+                        GenericArgument::Type(ty2),
+                    ) => match ident_str.as_str() {
+                        ident if ident == "HashMap" || ident == "BTreeMap" => {
+                            let inners = match (
+                                resolve_rust_ty(
+                                    ty1,
+                                    RustTypeContext::CollectionItem,
+                                ),
+                                resolve_rust_ty(
+                                    ty2,
+                                    RustTypeContext::CollectionItem,
+                                ),
+                            ) {
+                                (Ok(inner1), Ok(inner2)) => {
+                                    vec![inner1, inner2]
+                                }
+                                (Ok(inner1), Err(_)) => vec![inner1],
+                                (Err(_), Ok(inner2)) => vec![inner2],
+                                (Err(_), Err(_)) => vec![],
+                            };
 
-                                let composite = if ident == "HashMap" {
-                                    Composite::HashMap
-                                } else {
-                                    Composite::BTreeMap
-                                };
-                                TypeKind::Composite(composite, inners)
-                            }
-                            _ => {
-                                eprintln!("ident: {:#?}, args: {:#?}", ident, args);
-                                todo!(
+                            let composite = if ident == "HashMap" {
+                                Composite::HashMap
+                            } else {
+                                Composite::BTreeMap
+                            };
+                            TypeKind::Composite(composite, inners)
+                        }
+                        _ => {
+                            eprintln!("ident: {:#?}, args: {:#?}", ident, args);
+                            todo!(
                                 "Not yet handling custom angle bracketed types with {} type parameters",
                                 args.len()
                             )
-                            }
                         }
-                    }
+                    },
                     _ => TypeKind::Unknown,
                 },
                 _ => {


### PR DESCRIPTION
This PR adds two features to `ShankInstruction`s:
1. Parses Instruction variants with named arguments
2. Parses Instruction variants with multiple unnamed arguments (with names `instructionArgs0`, `instructionArgs1`, etc)

This is necessary to use Shank with SPL instructions. Closes #33

### Example: Instruction variant with named arguments 

Instructions with named arguments now works.  The following
```rust
#[derive(ShankInstruction)]
pub enum Instruction {
    #[account(0, name = "creator", sig)]
    #[account(1, name = "thing", mut)]
    CreateThing {
        some_args: SomeArgs,
        other_args: OtherArgs,
    },
    #[account(0, name = "creator", sig)]
    CloseThing(Option<u8>),
}
```
compiles to:
```json
{
  "version": "",
  "name": "",
  "instructions": [
    {
      "name": "CreateThing",
      "accounts": [
        {
          "name": "creator",
          "isMut": false,
          "isSigner": true
        },
        {
          "name": "thing",
          "isMut": true,
          "isSigner": false
        }
      ],
      "args": [
        {
          "name": "someArgs",
          "type": {
            "defined": "SomeArgs"
          }
        },
        {
          "name": "otherArgs",
          "type": {
            "defined": "OtherArgs"
          }
        }
      ],
      "discriminant": {
        "type": "u8",
        "value": 0
      }
    },
    {
      "name": "CloseThing",
      "accounts": [
        {
          "name": "creator",
          "isMut": false,
          "isSigner": true
        }
      ],
      "args": [
        {
          "name": "instructionArgs",
          "type": {
            "option": "u8"
          }
        }
      ],
      "discriminant": {
        "type": "u8",
        "value": 1
      }
    }
  ],
  "metadata": {
    "origin": "shank"
  }
}
```

### Example: Instruction variant with multiple unnamed arguments
Previously this would throw with an error saying `"An Instruction can only have one arg field"`. But now it works. The following
```rust
#[derive(ShankInstruction)]
pub enum Instruction {
    #[account(0, name = "creator", sig)]
    CloseThing(Option<u8>, ComplexArgs, ComplexArgs),
}
```
compiles to
```json
{
  "version": "",
  "name": "",
  "instructions": [
    {
      "name": "CloseThing",
      "accounts": [
        {
          "name": "creator",
          "isMut": false,
          "isSigner": true
        }
      ],
      "args": [
        {
          "name": "instructionArgs0",
          "type": {
            "option": "u8"
          }
        },
        {
          "name": "instructionArgs1",
          "type": {
            "defined": "ComplexArgs"
          }
        },
        {
          "name": "instructionArgs2",
          "type": {
            "defined": "ComplexArgs"
          }
        }
      ],
      "discriminant": {
        "type": "u8",
        "value": 0
      }
    }
  ],
  "metadata": {
    "origin": "shank"
  }
}
```

Todo:
- [x] Add change log