### PR TITLE
Add CLI program option for Program ID

### DIFF
--- a/shank-cli/src/lib.rs
+++ b/shank-cli/src/lib.rs
@@ -89,7 +89,7 @@ pub fn idl(out_dir: String, crate_root: Option<String>, program_id: Option<Strin
 
     // Extract IDL and convert to JSON
     let mut opts = ParseIdlOpts::default();
-    opts.override_program_address = program_id;
+    opts.program_address_override = program_id;
     let idl = extract_idl(lib_full_path, opts)?.ok_or(anyhow!("No IDL could be extracted"))?;
     let idl_json = idl.try_into_json()?;
 

--- a/shank-cli/src/lib.rs
+++ b/shank-cli/src/lib.rs
@@ -28,6 +28,10 @@ pub enum Command {
         /// Directory of program crate for which to generate the IDL.
         #[clap(short = 'r', long)]
         crate_root: Option<String>,
+
+        /// Manually specify and override the address in the IDL
+        #[clap(short = 'p', long)]
+        program_id: Option<String>,
     },
 }
 
@@ -36,7 +40,8 @@ pub fn entry(opts: Opts) -> Result<()> {
         Command::Idl {
             out_dir,
             crate_root,
-        } => idl(out_dir, crate_root),
+            program_id,
+        } => idl(out_dir, crate_root, program_id),
     }
 }
 
@@ -59,7 +64,7 @@ pub fn try_resolve_path(p: Option<String>, label: &str) -> Result<PathBuf> {
     Ok(p)
 }
 
-pub fn idl(out_dir: String, crate_root: Option<String>) -> Result<()> {
+pub fn idl(out_dir: String, crate_root: Option<String>, program_id: Option<String>) -> Result<()> {
     // Resolve input and output directories
     let crate_root = try_resolve_path(crate_root, "crate_root")?;
     let out_dir = try_resolve_path(Some(out_dir), "out_dir")?;
@@ -83,8 +88,9 @@ pub fn idl(out_dir: String, crate_root: Option<String>) -> Result<()> {
     let lib_full_path = lib_full_path_str.to_str().ok_or(anyhow!("Invalid Path"))?;
 
     // Extract IDL and convert to JSON
-    let idl = extract_idl(lib_full_path, ParseIdlOpts::default())?
-        .ok_or(anyhow!("No IDL could be extracted"))?;
+    let mut opts = ParseIdlOpts::default();
+    opts.override_program_address = program_id;
+    let idl = extract_idl(lib_full_path, opts)?.ok_or(anyhow!("No IDL could be extracted"))?;
     let idl_json = idl.try_into_json()?;
 
     // Write to JSON file

--- a/shank-idl/src/file.rs
+++ b/shank-idl/src/file.rs
@@ -60,7 +60,10 @@ impl ParseIdlConfig {
 // -----------------
 
 /// Parse an entire interface file.
-pub fn parse_file(filename: impl AsRef<Path>, config: &ParseIdlConfig) -> Result<Option<Idl>> {
+pub fn parse_file(
+    filename: impl AsRef<Path>,
+    config: &ParseIdlConfig,
+) -> Result<Option<Idl>> {
     let ctx = CrateContext::parse(filename)?;
 
     let constants = constants(&ctx)?;
@@ -104,7 +107,8 @@ fn accounts(ctx: &CrateContext) -> Result<Vec<IdlTypeDefinition>> {
 }
 
 fn instructions(ctx: &CrateContext) -> Result<Vec<IdlInstruction>> {
-    let instruction_enums = extract_instruction_enums(ctx.enums()).map_err(parse_error_into)?;
+    let instruction_enums =
+        extract_instruction_enums(ctx.enums()).map_err(parse_error_into)?;
 
     let mut instructions: Vec<IdlInstruction> = Vec::new();
     // TODO(thlorenz): Should we enforce only one Instruction Enum Arg?

--- a/shank-idl/src/file.rs
+++ b/shank-idl/src/file.rs
@@ -31,7 +31,7 @@ pub struct ParseIdlConfig {
     pub program_name: String,
     pub detect_custom_struct: DetectCustomTypeConfig,
     pub require_program_address: bool,
-    pub override_program_address: Option<String>,
+    pub program_address_override: Option<String>,
 }
 
 impl Default for ParseIdlConfig {
@@ -41,7 +41,7 @@ impl Default for ParseIdlConfig {
             program_name: Default::default(),
             detect_custom_struct: Default::default(),
             require_program_address: true,
-            override_program_address: None,
+            program_address_override: None,
         }
     }
 }
@@ -73,7 +73,7 @@ pub fn parse_file(filename: impl AsRef<Path>, config: &ParseIdlConfig) -> Result
     let metadata = metadata(
         &ctx,
         config.require_program_address,
-        config.override_program_address.as_ref(),
+        config.program_address_override.as_ref(),
     )?;
 
     let idl = Idl {
@@ -159,10 +159,10 @@ fn types(
 fn metadata(
     ctx: &CrateContext,
     require_program_address: bool,
-    override_program_address: Option<&String>,
+    program_address_override: Option<&String>,
 ) -> Result<IdlMetadata> {
     let macros: Vec<_> = ctx.macros().cloned().collect();
-    let address = if let Some(program_address) = override_program_address {
+    let address = if let Some(program_address) = program_address_override {
         Ok(Some(program_address.clone()))
     } else {
         match ProgramId::try_from(&macros[..]) {

--- a/shank-idl/src/lib.rs
+++ b/shank-idl/src/lib.rs
@@ -25,7 +25,7 @@ pub use file::*;
 pub struct ParseIdlOpts {
     pub detect_custom_struct: DetectCustomTypeConfig,
     pub require_program_address: bool,
-    pub override_program_address: Option<String>,
+    pub program_address_override: Option<String>,
 }
 
 impl Default for ParseIdlOpts {
@@ -33,7 +33,7 @@ impl Default for ParseIdlOpts {
         Self {
             detect_custom_struct: Default::default(),
             require_program_address: true,
-            override_program_address: None,
+            program_address_override: None,
         }
     }
 }
@@ -57,7 +57,7 @@ pub fn extract_idl(file: &str, opts: ParseIdlOpts) -> Result<Option<Idl>> {
             program_version: cargo.version(),
             detect_custom_struct: opts.detect_custom_struct,
             require_program_address: opts.require_program_address,
-            program_address_override: opts.override_program_address,
+            program_address_override: opts.program_address_override,
         },
     )
 }

--- a/shank-idl/src/lib.rs
+++ b/shank-idl/src/lib.rs
@@ -25,6 +25,7 @@ pub use file::*;
 pub struct ParseIdlOpts {
     pub detect_custom_struct: DetectCustomTypeConfig,
     pub require_program_address: bool,
+    pub override_program_address: Option<String>,
 }
 
 impl Default for ParseIdlOpts {
@@ -32,6 +33,7 @@ impl Default for ParseIdlOpts {
         Self {
             detect_custom_struct: Default::default(),
             require_program_address: true,
+            override_program_address: None,
         }
     }
 }
@@ -41,8 +43,7 @@ impl Default for ParseIdlOpts {
 // -----------------
 pub fn extract_idl(file: &str, opts: ParseIdlOpts) -> Result<Option<Idl>> {
     let file = shellexpand::tilde(file);
-    let manifest_from_path =
-        std::env::current_dir()?.join(PathBuf::from(&*file).parent().unwrap());
+    let manifest_from_path = std::env::current_dir()?.join(PathBuf::from(&*file).parent().unwrap());
     let cargo = Manifest::discover_from_path(manifest_from_path)?
         .ok_or_else(|| anyhow!("Cargo.toml not found"))?;
     let program_name = cargo
@@ -55,6 +56,7 @@ pub fn extract_idl(file: &str, opts: ParseIdlOpts) -> Result<Option<Idl>> {
             program_version: cargo.version(),
             detect_custom_struct: opts.detect_custom_struct,
             require_program_address: opts.require_program_address,
+            override_program_address: opts.override_program_address,
         },
     )
 }

--- a/shank-idl/src/lib.rs
+++ b/shank-idl/src/lib.rs
@@ -56,7 +56,7 @@ pub fn extract_idl(file: &str, opts: ParseIdlOpts) -> Result<Option<Idl>> {
             program_version: cargo.version(),
             detect_custom_struct: opts.detect_custom_struct,
             require_program_address: opts.require_program_address,
-            override_program_address: opts.override_program_address,
+            program_address_override: opts.override_program_address,
         },
     )
 }

--- a/shank-idl/src/lib.rs
+++ b/shank-idl/src/lib.rs
@@ -43,7 +43,8 @@ impl Default for ParseIdlOpts {
 // -----------------
 pub fn extract_idl(file: &str, opts: ParseIdlOpts) -> Result<Option<Idl>> {
     let file = shellexpand::tilde(file);
-    let manifest_from_path = std::env::current_dir()?.join(PathBuf::from(&*file).parent().unwrap());
+    let manifest_from_path =
+        std::env::current_dir()?.join(PathBuf::from(&*file).parent().unwrap());
     let cargo = Manifest::discover_from_path(manifest_from_path)?
         .ok_or_else(|| anyhow!("Cargo.toml not found"))?;
     let program_name = cargo

--- a/shank-macro-impl/src/macros/program_id.rs
+++ b/shank-macro-impl/src/macros/program_id.rs
@@ -40,17 +40,14 @@ impl TryFrom<&[ItemMacro]> for ProgramId {
             Err(ParseError::new_spanned(
                 &matches[0].0,
                 format!(
-                    "Found more than one program id candidate: {:?}",
-                    matches
-                        .iter()
-                        .map(|x| x.1.clone())
-                        .collect::<Vec<String>>()
+                    "Found more than one program id candidate: {:?}. Specify one with -p",
+                    matches.iter().map(|x| x.1.clone()).collect::<Vec<String>>()
                 ),
             ))
         } else if matches.is_empty() {
             Err(ParseError::new(
                 Span::call_site(),
-                "Could not find a `declare_id(\"<program-id>\")` invocation in the program",
+                "Could not find a `declare_id(\"<program-id>\")` invocation in the program. Override program address with -p",
             ))
         } else {
             Ok(ProgramId {
@@ -86,8 +83,9 @@ mod tests {
             },
             quote! {
                 solana_program::declare_id!("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s");
-            }
-        ]).expect("Should parse fine");
+            },
+        ])
+        .expect("Should parse fine");
 
         assert_eq!(
             parsed.id,
@@ -122,11 +120,12 @@ mod tests {
             quote! {
                 solana_program::declare_id!("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s");
             },
-        ]).expect_err("Should error");
+        ])
+        .expect_err("Should error");
 
         assert_eq!(
             err.to_string().as_str(),
-            "Found more than one program id candidate: [\"otherid\", \"metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s\"]"
+            "Found more than one program id candidate: [\"otherid\", \"metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s\"]. Specify one with -p"
         );
     }
 
@@ -139,11 +138,12 @@ mod tests {
             quote! {
                 declare_some_other_id!("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s");
             },
-        ]).expect_err("Should error");
+        ])
+        .expect_err("Should error");
 
         assert_eq!(
             err.to_string().as_str(),
-            "Could not find a `declare_id(\"<program-id>\")` invocation in the program"
+            "Could not find a `declare_id(\"<program-id>\")` invocation in the program. Override program address with -p"
         );
     }
 }

--- a/shank-macro-impl/src/macros/program_id.rs
+++ b/shank-macro-impl/src/macros/program_id.rs
@@ -40,14 +40,14 @@ impl TryFrom<&[ItemMacro]> for ProgramId {
             Err(ParseError::new_spanned(
                 &matches[0].0,
                 format!(
-                    "Found more than one program id candidate: {:?}. Specify one with -p",
+                    "Found more than one program id candidate: {:?}. You should either have exactly one `declare_id!` in your code or override the program id via -p.",
                     matches.iter().map(|x| x.1.clone()).collect::<Vec<String>>()
                 ),
             ))
         } else if matches.is_empty() {
             Err(ParseError::new(
                 Span::call_site(),
-                "Could not find a `declare_id(\"<program-id>\")` invocation in the program. Override program address with -p",
+                "Could not find a `declare_id(\"<program-id>\")` invocation in the program. If this is intentional provide a program address via the -p argument instead",
             ))
         } else {
             Ok(ProgramId {
@@ -125,7 +125,7 @@ mod tests {
 
         assert_eq!(
             err.to_string().as_str(),
-            "Found more than one program id candidate: [\"otherid\", \"metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s\"]. Specify one with -p"
+            "Found more than one program id candidate: [\"otherid\", \"metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s\"]. You should either have exactly one `declare_id!` in your code or override the program id via -p."
         );
     }
 
@@ -143,7 +143,7 @@ mod tests {
 
         assert_eq!(
             err.to_string().as_str(),
-            "Could not find a `declare_id(\"<program-id>\")` invocation in the program. Override program address with -p"
+            "Could not find a `declare_id(\"<program-id>\")` invocation in the program. If this is intentional provide a program address via the -p argument instead"
         );
     }
 }

--- a/shank-macro-impl/src/types/resolve_rust_ty.rs
+++ b/shank-macro-impl/src/types/resolve_rust_ty.rs
@@ -2,8 +2,9 @@ use std::{convert::TryFrom, ops::Deref};
 
 use quote::format_ident;
 use syn::{
-    spanned::Spanned, AngleBracketedGenericArguments, Expr, ExprLit, GenericArgument, Ident, Lit,
-    Path, PathArguments, PathSegment, Type, TypeArray, TypePath, TypeTuple,
+    spanned::Spanned, AngleBracketedGenericArguments, Expr, ExprLit,
+    GenericArgument, Ident, Lit, Path, PathArguments, PathSegment, Type,
+    TypeArray, TypePath, TypeTuple,
 };
 
 use super::{Composite, ParsedReference, Primitive, TypeKind, Value};
@@ -50,16 +51,28 @@ impl RustType {
             context: RustTypeContext::Default,
         }
     }
-    pub fn owned_primitive<T: Into<IdentWrap>>(ident: T, primitive: Primitive) -> Self {
+    pub fn owned_primitive<T: Into<IdentWrap>>(
+        ident: T,
+        primitive: Primitive,
+    ) -> Self {
         RustType::owned(ident, TypeKind::Primitive(primitive))
     }
     pub fn owned_string<T: Into<IdentWrap>>(ident: T) -> Self {
         RustType::owned(ident, TypeKind::Value(Value::String))
     }
-    pub fn owned_custom_value<T: Into<IdentWrap>>(ident: T, value: &str) -> Self {
-        RustType::owned(ident, TypeKind::Value(Value::Custom(value.to_string())))
+    pub fn owned_custom_value<T: Into<IdentWrap>>(
+        ident: T,
+        value: &str,
+    ) -> Self {
+        RustType::owned(
+            ident,
+            TypeKind::Value(Value::Custom(value.to_string())),
+        )
     }
-    pub fn owned_vec_primitive<T: Into<IdentWrap>>(ident: T, primitive: Primitive) -> Self {
+    pub fn owned_vec_primitive<T: Into<IdentWrap>>(
+        ident: T,
+        primitive: Primitive,
+    ) -> Self {
         RustType::owned(
             ident,
             TypeKind::Composite(
@@ -83,7 +96,10 @@ impl RustType {
         )
     }
 
-    pub fn owned_option_primitive<T: Into<IdentWrap>>(ident: T, primitive: Primitive) -> Self {
+    pub fn owned_option_primitive<T: Into<IdentWrap>>(
+        ident: T,
+        primitive: Primitive,
+    ) -> Self {
         RustType::owned(
             ident,
             TypeKind::Composite(
@@ -133,13 +149,18 @@ fn len_from_expr(expr: &Expr) -> ParseResult<usize> {
     }
 }
 
-pub fn resolve_rust_ty(ty: &Type, context: RustTypeContext) -> ParseResult<RustType> {
+pub fn resolve_rust_ty(
+    ty: &Type,
+    context: RustTypeContext,
+) -> ParseResult<RustType> {
     let (ty, reference) = match ty {
         Type::Reference(r) => {
             let pr = ParsedReference::from(r);
             (r.elem.as_ref(), pr)
         }
-        Type::Array(_) | Type::Path(_) | Type::Tuple(_) => (ty, ParsedReference::Owned),
+        Type::Array(_) | Type::Path(_) | Type::Tuple(_) => {
+            (ty, ParsedReference::Owned)
+        }
         ty => {
             eprintln!("{:#?}", ty);
             return Err(ParseError::new(
@@ -156,7 +177,9 @@ pub fn resolve_rust_ty(ty: &Type, context: RustTypeContext) -> ParseResult<RustT
         }
         Type::Array(TypeArray { elem, len, .. }) => {
             let (inner_ident, inner_kind) = match elem.deref() {
-                Type::Path(TypePath { path, .. }) => ident_and_kind_from_path(path),
+                Type::Path(TypePath { path, .. }) => {
+                    ident_and_kind_from_path(path)
+                }
                 _ => {
                     return Err(ParseError::new(
                         ty.span(),
@@ -171,7 +194,8 @@ pub fn resolve_rust_ty(ty: &Type, context: RustTypeContext) -> ParseResult<RustT
                 reference: ParsedReference::Owned,
                 context: RustTypeContext::CollectionItem,
             };
-            let kind = TypeKind::Composite(Composite::Array(len), vec![inner_ty]);
+            let kind =
+                TypeKind::Composite(Composite::Array(len), vec![inner_ty]);
             (format_ident!("Array"), kind)
         }
         Type::Tuple(TypeTuple { elems, .. }) => {
@@ -257,31 +281,54 @@ fn ident_to_kind(ident: &Ident, arguments: &PathArguments) -> TypeKind {
         }
 
         // Composite Types
-        PathArguments::AngleBracketed(AngleBracketedGenericArguments { args, .. }) => {
+        PathArguments::AngleBracketed(AngleBracketedGenericArguments {
+            args,
+            ..
+        }) => {
             match args.len() {
                 // -----------------
                 // Single Type Parameter
                 // -----------------
                 1 => match &args[0] {
                     GenericArgument::Type(ty) => match ident_str.as_str() {
-                        "Vec" => match resolve_rust_ty(ty, RustTypeContext::CollectionItem) {
-                            Ok(inner) => TypeKind::Composite(Composite::Vec, vec![inner]),
-                            Err(_) => TypeKind::Composite(Composite::Vec, vec![]),
+                        "Vec" => match resolve_rust_ty(
+                            ty,
+                            RustTypeContext::CollectionItem,
+                        ) {
+                            Ok(inner) => {
+                                TypeKind::Composite(Composite::Vec, vec![inner])
+                            }
+                            Err(_) => {
+                                TypeKind::Composite(Composite::Vec, vec![])
+                            }
                         },
                         "COption" | "Option" => {
-                            match resolve_rust_ty(ty, RustTypeContext::OptionItem) {
-                                Ok(inner) => TypeKind::Composite(Composite::Option, vec![inner]),
-                                Err(_) => TypeKind::Composite(Composite::Option, vec![]),
+                            match resolve_rust_ty(
+                                ty,
+                                RustTypeContext::OptionItem,
+                            ) {
+                                Ok(inner) => TypeKind::Composite(
+                                    Composite::Option,
+                                    vec![inner],
+                                ),
+                                Err(_) => TypeKind::Composite(
+                                    Composite::Option,
+                                    vec![],
+                                ),
                             }
                         }
-                        _ => match resolve_rust_ty(ty, RustTypeContext::CustomItem) {
+                        _ => match resolve_rust_ty(
+                            ty,
+                            RustTypeContext::CustomItem,
+                        ) {
                             Ok(inner) => TypeKind::Composite(
                                 Composite::Custom(ident_str.clone()),
                                 vec![inner],
                             ),
-                            Err(_) => {
-                                TypeKind::Composite(Composite::Custom(ident_str.clone()), vec![])
-                            }
+                            Err(_) => TypeKind::Composite(
+                                Composite::Custom(ident_str.clone()),
+                                vec![],
+                            ),
                         },
                     },
                     _ => TypeKind::Unknown,
@@ -290,37 +337,44 @@ fn ident_to_kind(ident: &Ident, arguments: &PathArguments) -> TypeKind {
                 // Two Type Parameters
                 // -----------------
                 2 => match (&args[0], &args[1]) {
-                    (GenericArgument::Type(ty1), GenericArgument::Type(ty2)) => {
-                        match ident_str.as_str() {
-                            ident if ident == "HashMap" || ident == "BTreeMap" => {
-                                let inners = match (
-                                    resolve_rust_ty(ty1, RustTypeContext::CollectionItem),
-                                    resolve_rust_ty(ty2, RustTypeContext::CollectionItem),
-                                ) {
-                                    (Ok(inner1), Ok(inner2)) => {
-                                        vec![inner1, inner2]
-                                    }
-                                    (Ok(inner1), Err(_)) => vec![inner1],
-                                    (Err(_), Ok(inner2)) => vec![inner2],
-                                    (Err(_), Err(_)) => vec![],
-                                };
+                    (
+                        GenericArgument::Type(ty1),
+                        GenericArgument::Type(ty2),
+                    ) => match ident_str.as_str() {
+                        ident if ident == "HashMap" || ident == "BTreeMap" => {
+                            let inners = match (
+                                resolve_rust_ty(
+                                    ty1,
+                                    RustTypeContext::CollectionItem,
+                                ),
+                                resolve_rust_ty(
+                                    ty2,
+                                    RustTypeContext::CollectionItem,
+                                ),
+                            ) {
+                                (Ok(inner1), Ok(inner2)) => {
+                                    vec![inner1, inner2]
+                                }
+                                (Ok(inner1), Err(_)) => vec![inner1],
+                                (Err(_), Ok(inner2)) => vec![inner2],
+                                (Err(_), Err(_)) => vec![],
+                            };
 
-                                let composite = if ident == "HashMap" {
-                                    Composite::HashMap
-                                } else {
-                                    Composite::BTreeMap
-                                };
-                                TypeKind::Composite(composite, inners)
-                            }
-                            _ => {
-                                eprintln!("ident: {:#?}, args: {:#?}", ident, args);
-                                todo!(
+                            let composite = if ident == "HashMap" {
+                                Composite::HashMap
+                            } else {
+                                Composite::BTreeMap
+                            };
+                            TypeKind::Composite(composite, inners)
+                        }
+                        _ => {
+                            eprintln!("ident: {:#?}, args: {:#?}", ident, args);
+                            todo!(
                                 "Not yet handling custom angle bracketed types with {} type parameters",
                                 args.len()
                             )
-                            }
                         }
-                    }
+                    },
                     _ => TypeKind::Unknown,
                 },
                 _ => {

--- a/shank-macro-impl/src/types/resolve_rust_ty.rs
+++ b/shank-macro-impl/src/types/resolve_rust_ty.rs
@@ -302,21 +302,18 @@ fn ident_to_kind(ident: &Ident, arguments: &PathArguments) -> TypeKind {
                                 TypeKind::Composite(Composite::Vec, vec![])
                             }
                         },
-                        "COption" | "Option" => {
-                            match resolve_rust_ty(
-                                ty,
-                                RustTypeContext::OptionItem,
-                            ) {
-                                Ok(inner) => TypeKind::Composite(
-                                    Composite::Option,
-                                    vec![inner],
-                                ),
-                                Err(_) => TypeKind::Composite(
-                                    Composite::Option,
-                                    vec![],
-                                ),
+                        "Option" => match resolve_rust_ty(
+                            ty,
+                            RustTypeContext::OptionItem,
+                        ) {
+                            Ok(inner) => TypeKind::Composite(
+                                Composite::Option,
+                                vec![inner],
+                            ),
+                            Err(_) => {
+                                TypeKind::Composite(Composite::Option, vec![])
                             }
-                        }
+                        },
                         _ => match resolve_rust_ty(
                             ty,
                             RustTypeContext::CustomItem,


### PR DESCRIPTION
Provide -p to override program address.

Also adds support for COptions by treating them as normal Option types. Closes https://github.com/metaplex-foundation/shank/issues/22.

Works with spl-token program via `cargo +1.59.0 run -- idl -r <YOUR-SYS-PATH>/solana-program-library/token/program -o ./tmp/token/idl -p TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA.`