### PR TITLE
feat: support HashSet and BTreeSet

### DIFF
--- a/shank-idl/src/idl_type.rs
+++ b/shank-idl/src/idl_type.rs
@@ -31,6 +31,8 @@ pub enum IdlType {
     Vec(Box<IdlType>),
     HashMap(Box<IdlType>, Box<IdlType>),
     BTreeMap(Box<IdlType>, Box<IdlType>),
+    HashSet(Box<IdlType>),
+    BTreeSet(Box<IdlType>),
 }
 
 impl TryFrom<RustType> for IdlType {
@@ -140,6 +142,28 @@ impl TryFrom<RustType> for IdlType {
                         }
                     }
                 }
+                Composite::HashSet => match inners.get(0).cloned() {
+                    Some(inner) => {
+                        let inner_idl: IdlType = inner.try_into()?;
+                        IdlType::HashSet(Box::new(inner_idl))
+                    }
+                    _ => {
+                        anyhow::bail!(
+                            "Rust HashSet Composite needs one inner type"
+                        )
+                    }
+                },
+                Composite::BTreeSet => match inners.get(0).cloned() {
+                    Some(inner) => {
+                        let inner_idl: IdlType = inner.try_into()?;
+                        IdlType::BTreeSet(Box::new(inner_idl))
+                    }
+                    _ => {
+                        anyhow::bail!(
+                            "Rust BTreeSet Composite needs one inner type"
+                        )
+                    }
+                },
                 Composite::Custom(_) => {
                     anyhow::bail!(
                         "Rust Custom Composite IDL type not yet supported"

--- a/shank-idl/tests/fixtures/types/valid_multiple_sets.json
+++ b/shank-idl/tests/fixtures/types/valid_multiple_sets.json
@@ -1,0 +1,138 @@
+{
+  "version": "",
+  "name": "",
+  "instructions": [],
+  "types": [
+    {
+      "name": "OneHashSetStruct",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "u8Set",
+            "type": {
+              "hashSet": "u8"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MultipleHashSetsStruct",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "u8Set",
+            "type": {
+              "hashSet": "u8"
+            }
+          },
+          {
+            "name": "stringSet",
+            "type": {
+              "hashSet": "string"
+            }
+          },
+          {
+            "name": "optionI128Set",
+            "type": {
+              "hashSet": {
+                "option": "i128"
+              }
+            }
+          },
+          {
+            "name": "vecCustomSet",
+            "type": {
+              "hashSet": {
+                "vec": {
+                  "defined": "Custom"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "OneBTreeSetStruct",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "u8Set",
+            "type": {
+              "bTreeSet": "u8"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MultipleBTreeSetsStruct",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "u8Set",
+            "type": {
+              "bTreeSet": "u8"
+            }
+          },
+          {
+            "name": "stringSet",
+            "type": {
+              "bTreeSet": "string"
+            }
+          },
+          {
+            "name": "optionI128Set",
+            "type": {
+              "bTreeSet": {
+                "option": "i128"
+              }
+            }
+          },
+          {
+            "name": "vecCustomSet",
+            "type": {
+              "bTreeSet": {
+                "vec": {
+                  "defined": "Custom"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "NestedSetsStruct",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vecHashMapU8",
+            "type": {
+              "vec": {
+                "hashSet": "u8"
+              }
+            }
+          },
+          {
+            "name": "optionBtreeMapU8",
+            "type": {
+              "option": {
+                "bTreeSet": "u8"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "metadata": {
+    "origin": "shank"
+  }
+}

--- a/shank-idl/tests/fixtures/types/valid_multiple_sets.rs
+++ b/shank-idl/tests/fixtures/types/valid_multiple_sets.rs
@@ -1,0 +1,31 @@
+#[derive(BorshSerialize)]
+pub struct OneHashSetStruct {
+    pub u8_set: HashSet<u8>,
+}
+
+#[derive(BorshSerialize)]
+pub struct MultipleHashSetsStruct {
+    pub u8_set: HashSet<u8>,
+    pub string_set: HashSet<String>,
+    pub option_i128_set: HashSet<Option<i128>>,
+    pub vec_custom_set: HashSet<Vec<Custom>>,
+}
+
+#[derive(BorshSerialize)]
+pub struct OneBTreeSetStruct {
+    pub u8_set: BTreeSet<u8>,
+}
+
+#[derive(BorshSerialize)]
+pub struct MultipleBTreeSetsStruct {
+    pub u8_set: BTreeSet<u8>,
+    pub string_set: BTreeSet<String>,
+    pub option_i128_set: BTreeSet<Option<i128>>,
+    pub vec_custom_set: BTreeSet<Vec<Custom>>,
+}
+
+#[derive(BorshSerialize)]
+pub struct NestedSetsStruct {
+    pub vec_hash_map_u8: Vec<HashSet<u8>>,
+    pub option_btree_map_u8: Option<BTreeSet<u8>>,
+}

--- a/shank-idl/tests/types.rs
+++ b/shank-idl/tests/types.rs
@@ -93,6 +93,22 @@ fn type_valid_maps() {
 }
 
 #[test]
+fn type_valid_sets() {
+    let file = fixtures_dir().join("valid_multiple_sets.rs");
+    let idl = parse_file(&file, &ParseIdlConfig::optional_program_address())
+        .expect("Parsing should not fail")
+        .expect("File contains IDL");
+    // eprintln!("{}", serde_json::to_string_pretty(&idl).unwrap());
+
+    let expected_idl: Idl = serde_json::from_str(include_str!(
+        "./fixtures/types/valid_multiple_sets.json"
+    ))
+    .unwrap();
+
+    assert_eq!(idl, expected_idl);
+}
+
+#[test]
 fn type_valid_tuples() {
     let file = fixtures_dir().join("valid_multiple_tuples.rs");
     let idl = parse_file(&file, &ParseIdlConfig::optional_program_address())

--- a/shank-macro-impl/src/types/type_kind.rs
+++ b/shank-macro-impl/src/types/type_kind.rs
@@ -132,7 +132,9 @@ impl TypeKind {
             TypeKind::Primitive(_) => None,
             TypeKind::Value(_) => None,
             TypeKind::Composite(Composite::Vec, inners)
-            | TypeKind::Composite(Composite::Array(_), inners) => {
+            | TypeKind::Composite(Composite::Array(_), inners)
+            | TypeKind::Composite(Composite::HashSet, inners)
+            | TypeKind::Composite(Composite::BTreeSet, inners) => {
                 inners.get(0).cloned()
             }
             TypeKind::Composite(_, _) => None,
@@ -298,6 +300,8 @@ pub enum Composite {
     Option,
     HashMap,
     BTreeMap,
+    HashSet,
+    BTreeSet,
     Custom(String),
 }
 
@@ -310,6 +314,8 @@ impl Debug for Composite {
             Composite::Option => write!(f, "Composite::Option"),
             Composite::HashMap => write!(f, "Composite::HashMap"),
             Composite::BTreeMap => write!(f, "Composite::BTreeMap"),
+            Composite::HashSet => write!(f, "Composite::HashSet"),
+            Composite::BTreeSet => write!(f, "Composite::BTreeSet"),
             Composite::Custom(name) => {
                 write!(f, "Composite::Custom(\"{}\")", name)
             }


### PR DESCRIPTION
## Summary

Adding support for `HashSet` and `BTreeSet`.

They are added to the IDL as follows:

```json
{
  "type": {
    "kind": "struct",
    "fields": [
      {
        "name": "u8Set",
        "type": {
          "hashSet": "u8"
        }
      }
    ]
  }
}
```

```json
"type": {
  "kind": "struct",
  "fields": [
    {
      "name": "vecHashMapU8",
      "type": {
        "vec": {
          "hashSet": "u8"
        }
      }
    },
    {
      "name": "optionBtreeMapU8",
      "type": {
        "option": {
          "bTreeSet": "u8"
        }
      }
    }
  ]
}
```

Related PR: https://github.com/metaplex-foundation/shank/pull/30 where the same was implemented
for maps.

Helps resolve: https://github.com/metaplex-foundation/solita/issues/85
