### PR TITLE
feat: optional instruction acccounts defaulting to program_id

### DIFF
--- a/shank-idl/tests/fixtures/instructions/single_file/instruction_with_optional_account_defaulting.json
+++ b/shank-idl/tests/fixtures/instructions/single_file/instruction_with_optional_account_defaulting.json
@@ -1,0 +1,53 @@
+{
+  "version": "",
+  "name": "",
+  "instructions": [
+    {
+      "name": "CreateThing",
+      "accounts": [
+        {
+          "name": "creator",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "thing",
+          "isMut": true,
+          "isSigner": false,
+          "optional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "someArgs",
+          "type": {
+            "defined": "SomeArgs"
+          }
+        }
+      ],
+      "defaultOptionalAccounts": true,
+      "discriminant": {
+        "type": "u8",
+        "value": 0
+      }
+    },
+    {
+      "name": "CloseThing",
+      "accounts": [
+        {
+          "name": "creator",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [],
+      "discriminant": {
+        "type": "u8",
+        "value": 1
+      }
+    }
+  ],
+  "metadata": {
+    "origin": "shank"
+  }
+}

--- a/shank-idl/tests/fixtures/instructions/single_file/instruction_with_optional_account_defaulting.rs
+++ b/shank-idl/tests/fixtures/instructions/single_file/instruction_with_optional_account_defaulting.rs
@@ -1,0 +1,9 @@
+#[derive(ShankInstruction)]
+pub enum Instruction {
+    #[default_optional_accounts]
+    #[account(0, name = "creator", sig)]
+    #[account(1, name = "thing", mut, optional)]
+    CreateThing(SomeArgs),
+    #[account(name = "creator", sig)]
+    CloseThing,
+}

--- a/shank-idl/tests/instructions.rs
+++ b/shank-idl/tests/instructions.rs
@@ -95,6 +95,23 @@ fn instruction_from_single_file_with_optional_account() {
 }
 
 #[test]
+fn instruction_from_single_file_with_optional_account_defaulting() {
+    let file = fixtures_dir()
+        .join("single_file")
+        .join("instruction_with_optional_account_defaulting.rs");
+    let idl = parse_file(&file, &ParseIdlConfig::optional_program_address())
+        .expect("Parsing should not fail")
+        .expect("File contains IDL");
+
+    let expected_idl: Idl = serde_json::from_str(include_str!(
+        "./fixtures/instructions/single_file/instruction_with_optional_account_defaulting.json"
+    ))
+    .unwrap();
+
+    assert_eq!(idl, expected_idl);
+}
+
+#[test]
 fn instruction_from_single_file_invalid_attr() {
     let file = fixtures_dir()
         .join("single_file")

--- a/shank-macro-impl/src/instruction/account_attrs_test.rs
+++ b/shank-macro-impl/src/instruction/account_attrs_test.rs
@@ -60,7 +60,7 @@ impl From<&InstructionAccounts> for Vec<InstructionAccountWithoutIdent> {
     }
 }
 
-fn assert_instruction_account_matches(
+pub fn assert_instruction_account_matches(
     acc_actual: &InstructionAccount,
     acc_expected: InstructionAccountWithoutIdent,
 ) {

--- a/shank-macro-impl/src/instruction/instruction.rs
+++ b/shank-macro-impl/src/instruction/instruction.rs
@@ -1,4 +1,7 @@
-use std::convert::{TryFrom, TryInto};
+use std::{
+    collections::HashSet,
+    convert::{TryFrom, TryInto},
+};
 use syn::{Attribute, Error as ParseError, ItemEnum, Result as ParseResult};
 
 use syn::Ident;
@@ -87,7 +90,7 @@ pub struct InstructionVariant {
     pub ident: Ident,
     pub field_tys: InstructionVariantFields,
     pub accounts: Vec<InstructionAccount>,
-    pub strategies: Vec<InstructionStrategy>,
+    pub strategies: HashSet<InstructionStrategy>,
     pub discriminant: usize,
 }
 

--- a/shank-macro-impl/src/instruction/instruction.rs
+++ b/shank-macro-impl/src/instruction/instruction.rs
@@ -10,7 +10,10 @@ use crate::{
     DERIVE_INSTRUCTION_ATTR,
 };
 
-use super::account_attrs::{InstructionAccount, InstructionAccounts};
+use super::{
+    account_attrs::{InstructionAccount, InstructionAccounts},
+    InstructionStrategies, InstructionStrategy,
+};
 
 // -----------------
 // Instruction
@@ -84,6 +87,7 @@ pub struct InstructionVariant {
     pub ident: Ident,
     pub field_tys: InstructionVariantFields,
     pub accounts: Vec<InstructionAccount>,
+    pub strategies: Vec<InstructionStrategy>,
     pub discriminant: usize,
 }
 
@@ -124,11 +128,13 @@ impl TryFrom<&ParsedEnumVariant> for InstructionVariant {
 
         let attrs: &[Attribute] = attrs.as_ref();
         let accounts: InstructionAccounts = attrs.try_into()?;
+        let strategies: InstructionStrategies = attrs.into();
 
         Ok(Self {
             ident: ident.clone(),
             field_tys,
             accounts: accounts.0,
+            strategies: strategies.0,
             discriminant: *discriminant,
         })
     }

--- a/shank-macro-impl/src/instruction/instruction_test.rs
+++ b/shank-macro-impl/src/instruction/instruction_test.rs
@@ -27,6 +27,7 @@ fn assert_instruction_variant(
         field_tys,
         accounts,
         discriminant,
+        ..
     } = variant;
 
     assert_eq!(ident.to_string(), name);

--- a/shank-macro-impl/src/instruction/mod.rs
+++ b/shank-macro-impl/src/instruction/mod.rs
@@ -1,12 +1,16 @@
 mod account_attrs;
 mod extract_instructions;
 mod instruction;
+mod strategy_attrs;
 
 pub use account_attrs::*;
 pub use extract_instructions::*;
 pub use instruction::*;
+pub use strategy_attrs::*;
 
 #[cfg(test)]
 mod account_attrs_test;
 #[cfg(test)]
 mod instruction_test;
+#[cfg(test)]
+mod strategy_attrs_test;

--- a/shank-macro-impl/src/instruction/strategy_attrs.rs
+++ b/shank-macro-impl/src/instruction/strategy_attrs.rs
@@ -1,14 +1,16 @@
+use std::collections::HashSet;
+
 use syn::Attribute;
 
 const DEFAULT_OPTIONAL_ACCOUNTS: &str = "default_optional_accounts";
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub enum InstructionStrategy {
     DefaultOptionalAccounts,
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct InstructionStrategies(pub Vec<InstructionStrategy>);
+pub struct InstructionStrategies(pub HashSet<InstructionStrategy>);
 
 impl InstructionStrategy {
     pub fn from_account_attr(attr: &Attribute) -> Option<InstructionStrategy> {
@@ -28,7 +30,7 @@ impl From<&[Attribute]> for InstructionStrategies {
         let strategies = attrs
             .into_iter()
             .filter_map(InstructionStrategy::from_account_attr)
-            .collect::<Vec<InstructionStrategy>>();
+            .collect::<HashSet<InstructionStrategy>>();
 
         InstructionStrategies(strategies)
     }

--- a/shank-macro-impl/src/instruction/strategy_attrs.rs
+++ b/shank-macro-impl/src/instruction/strategy_attrs.rs
@@ -1,0 +1,35 @@
+use syn::Attribute;
+
+const DEFAULT_OPTIONAL_ACCOUNTS: &str = "default_optional_accounts";
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum InstructionStrategy {
+    DefaultOptionalAccounts,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct InstructionStrategies(pub Vec<InstructionStrategy>);
+
+impl InstructionStrategy {
+    pub fn from_account_attr(attr: &Attribute) -> Option<InstructionStrategy> {
+        match attr
+            .path
+            .get_ident()
+            .map(|x| x.to_string().as_str() == DEFAULT_OPTIONAL_ACCOUNTS)
+        {
+            Some(true) => Some(InstructionStrategy::DefaultOptionalAccounts),
+            _ => None,
+        }
+    }
+}
+
+impl From<&[Attribute]> for InstructionStrategies {
+    fn from(attrs: &[Attribute]) -> Self {
+        let strategies = attrs
+            .into_iter()
+            .filter_map(InstructionStrategy::from_account_attr)
+            .collect::<Vec<InstructionStrategy>>();
+
+        InstructionStrategies(strategies)
+    }
+}

--- a/shank-macro-impl/src/instruction/strategy_attrs_test.rs
+++ b/shank-macro-impl/src/instruction/strategy_attrs_test.rs
@@ -51,9 +51,10 @@ fn instruction_with_default_optional_accounts() {
     );
 
     assert_eq!(strategies.0.len(), 1, "includes one instruction strategy");
-    assert_eq!(
-        strategies.0[0],
-        InstructionStrategy::DefaultOptionalAccounts,
+    assert!(
+        strategies
+            .0
+            .contains(&InstructionStrategy::DefaultOptionalAccounts),
         "to default optional accounts"
     );
 }

--- a/shank-macro-impl/src/instruction/strategy_attrs_test.rs
+++ b/shank-macro-impl/src/instruction/strategy_attrs_test.rs
@@ -1,0 +1,85 @@
+use std::convert::TryInto;
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::ItemEnum;
+
+use syn::{Attribute, Result as ParseResult};
+
+use crate::instruction::{
+    account_attrs_test::{
+        assert_instruction_account_matches, InstructionAccountWithoutIdent,
+    },
+    InstructionStrategy,
+};
+
+use super::{account_attrs::InstructionAccounts, InstructionStrategies};
+
+fn parse_first_enum_variant_attrs(
+    code: TokenStream,
+) -> ParseResult<(InstructionAccounts, InstructionStrategies)> {
+    let parsed =
+        syn::parse2::<ItemEnum>(code).expect("Should parse successfully");
+    let attrs: &[Attribute] = parsed.variants.first().unwrap().attrs.as_ref();
+    let instruction_accounts = attrs.try_into()?;
+    let instruction_strategies = attrs.into();
+    Ok((instruction_accounts, instruction_strategies))
+}
+
+#[test]
+fn instruction_with_default_optional_accounts() {
+    let (accounts, strategies) = parse_first_enum_variant_attrs(quote! {
+        #[derive(ShankInstruction)]
+        pub enum Instructions {
+            #[default_optional_accounts]
+            #[account(name="authority")]
+            NonIndexed
+        }
+    })
+    .expect("Should parse fine");
+
+    assert_instruction_account_matches(
+        &accounts.0[0],
+        InstructionAccountWithoutIdent {
+            index: None,
+            name: "authority".to_string(),
+            writable: false,
+            signer: false,
+            desc: None,
+            optional: false,
+        },
+    );
+
+    assert_eq!(strategies.0.len(), 1, "includes one instruction strategy");
+    assert_eq!(
+        strategies.0[0],
+        InstructionStrategy::DefaultOptionalAccounts,
+        "to default optional accounts"
+    );
+}
+
+#[test]
+fn instruction_without_default_optional_accounts() {
+    let (accounts, strategies) = parse_first_enum_variant_attrs(quote! {
+        #[derive(ShankInstruction)]
+        pub enum Instructions {
+            #[account(name="authority")]
+            NonIndexed
+        }
+    })
+    .expect("Should parse fine");
+
+    assert_instruction_account_matches(
+        &accounts.0[0],
+        InstructionAccountWithoutIdent {
+            index: None,
+            name: "authority".to_string(),
+            writable: false,
+            signer: false,
+            desc: None,
+            optional: false,
+        },
+    );
+
+    assert_eq!(strategies.0.len(), 0, "includes no instruction strategy");
+}

--- a/shank-macro/src/lib.rs
+++ b/shank-macro/src/lib.rs
@@ -78,6 +78,22 @@ pub fn shank_account(input: TokenStream) -> TokenStream {
 /// - `system_program` uses `SystemProgram.programId`
 /// - `rent` uses `SYSVAR_RENT_PUBKEY`
 ///
+/// # Strategies
+///
+/// ## Defaulting Optional Accounts
+///
+/// When the `#[default_optional_accounts]` attribute is added to an Instruction enum, shank will mark it
+/// such that optional accounts should default to the `progam_id` if they are not provided by the client.
+/// Thus their position is static and optional accounts that are set can follow ones that are not.
+///
+/// The default strategy (without `#[default_optional_accounts]`) is to just omit unset optional
+/// accounts from the accounts array.
+///
+/// **NOTE**: shank doesn't do anything different here aside from setting a flag for the
+/// particular instruction. Thus adding that strategy to an instruction enum is merely advisory and
+/// will is expected to be properly respected by code generator tools like
+/// [solita](https://github.com/metaplex-foundation/solita).
+///
 /// # Examples
 ///
 /// ```
@@ -116,7 +132,10 @@ pub fn shank_account(input: TokenStream) -> TokenStream {
 ///     ActivateVault(NumberOfShareArgs)
 /// }
 /// ```
-#[proc_macro_derive(ShankInstruction, attributes(account))]
+#[proc_macro_derive(
+    ShankInstruction,
+    attributes(account, default_optional_accounts)
+)]
 pub fn shank_instruction(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     derive_instruction(input)


### PR DESCRIPTION
# Summary

This PR adds the `default_optional_accounts` instruction attribute that sets the strategy for
code generators regarding how optional accounts should be included in the accounts array.

If it is present all accounts not provided should be set to the `program_id` instead of just
being omitted (which is the default strategy).

## Example

```rs
#[derive(ShankInstruction)]
pub enum Instruction {
    #[default_optional_accounts]
    #[account(0, name = "creator", sig)]
    #[account(1, name = "thing", mut, optional)]
    CreateThing(SomeArgs),
    #[account(name = "creator", sig)]
    CloseThing,
}
```

Related Issue in solita: https://github.com/metaplex-foundation/solita/issues/93
Related PR in solita:    https://github.com/metaplex-foundation/solita/pull/94
