### PR TITLE
Fix: module collision

### DIFF
--- a/shank-macro-impl/src/krate/module_context.rs
+++ b/shank-macro-impl/src/krate/module_context.rs
@@ -69,7 +69,6 @@ impl ParsedModule {
 
         while let Some(to_parse) = unparsed.pop() {
             let path = format!("{}::{}", to_parse.path, to_parse.name);
-            let name = to_parse.name;
             let module =
                 Self::from_item_mod(&to_parse.file, &path, to_parse.item)?;
 
@@ -79,8 +78,7 @@ impl ParsedModule {
                 path: module.path.clone(),
                 name: item.ident.to_string(),
             }));
-            let module_key = format!("{path}::{name}");
-            modules.insert(module_key, module);
+            modules.insert(path, module);
         }
 
         modules.insert(root_mod.name.clone(), root_mod);

--- a/shank-macro-impl/src/krate/module_context.rs
+++ b/shank-macro-impl/src/krate/module_context.rs
@@ -79,7 +79,8 @@ impl ParsedModule {
                 path: module.path.clone(),
                 name: item.ident.to_string(),
             }));
-            modules.insert(name.clone(), module);
+            let module_key = format!("{path}::{name}");
+            modules.insert(module_key, module);
         }
 
         modules.insert(root_mod.name.clone(), root_mod);


### PR DESCRIPTION
If there are multiple modules with the same name in a crate (which is possible as long as they are in separate scopes), the last one processed will overwrite the initial. This fix just expands the `modules` key to use the path instead.