### PR TITLE
Update idl output

### DIFF
--- a/shank-idl/src/idl_instruction.rs
+++ b/shank-idl/src/idl_instruction.rs
@@ -43,7 +43,7 @@ pub struct IdlInstruction {
     pub accounts: Vec<IdlAccountItem>,
     pub args: Vec<IdlField>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub default_optional_accounts: Option<bool>,
+    pub legacy_optional_accounts_strategy: Option<bool>,
     pub discriminant: IdlInstructionDiscriminant,
 }
 
@@ -98,8 +98,8 @@ impl TryFrom<InstructionVariant> for IdlInstruction {
         let args: Vec<IdlField> = parsed_idl_fields?;
 
         let accounts = accounts.into_iter().map(IdlAccountItem::from).collect();
-        let default_optional_accounts = if strategies
-            .contains(&InstructionStrategy::DefaultOptionalAccounts)
+        let legacy_optional_accounts_strategy = if strategies
+            .contains(&InstructionStrategy::LegacyOptionalAccounts)
         {
             Some(true)
         } else {
@@ -121,7 +121,7 @@ impl TryFrom<InstructionVariant> for IdlInstruction {
             name,
             accounts,
             args,
-            default_optional_accounts,
+            legacy_optional_accounts_strategy,
             discriminant: (discriminant as u8).into(),
         })
     }
@@ -179,9 +179,9 @@ pub struct IdlAccount {
     pub is_mut: bool,
     pub is_signer: bool,
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub desc: Option<String>,
+    pub docs: Option<Vec<String>>,
     #[serde(skip_serializing_if = "is_false", default)]
-    pub optional: bool,
+    pub is_optional: bool,
 }
 
 impl From<InstructionAccount> for IdlAccount {
@@ -198,8 +198,8 @@ impl From<InstructionAccount> for IdlAccount {
             name: name.to_mixed_case(),
             is_mut: writable,
             is_signer: signer,
-            desc,
-            optional,
+            docs: desc.map(|desc| vec![desc]),
+            is_optional: optional,
         }
     }
 }

--- a/shank-idl/src/idl_instruction.rs
+++ b/shank-idl/src/idl_instruction.rs
@@ -178,10 +178,12 @@ pub struct IdlAccount {
     pub name: String,
     pub is_mut: bool,
     pub is_signer: bool,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub docs: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "is_false", default)]
+    pub is_optional_signer: bool,
     #[serde(skip_serializing_if = "is_false", default)]
     pub is_optional: bool,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub docs: Option<Vec<String>>,
 }
 
 impl From<InstructionAccount> for IdlAccount {
@@ -192,6 +194,7 @@ impl From<InstructionAccount> for IdlAccount {
             signer,
             desc,
             optional,
+            optional_signer,
             ..
         } = acc;
         Self {
@@ -200,6 +203,7 @@ impl From<InstructionAccount> for IdlAccount {
             is_signer: signer,
             docs: desc.map(|desc| vec![desc]),
             is_optional: optional,
+            is_optional_signer: optional_signer,
         }
     }
 }

--- a/shank-idl/tests/fixtures/instructions/single_file/instruction_with_docs.json
+++ b/shank-idl/tests/fixtures/instructions/single_file/instruction_with_docs.json
@@ -1,0 +1,47 @@
+{
+  "version": "",
+  "name": "",
+  "instructions": [
+    {
+      "name": "CreateThing",
+      "accounts": [
+        {
+          "name": "creator",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "The creator of the thing"
+          ]
+        },
+        {
+          "name": "thing",
+          "isMut": true,
+          "isSigner": false,
+          "docs": [
+            "The thing to create"
+          ]
+        }
+      ],
+      "args": [],
+      "discriminant": { "type": "u8", "value": 0 }
+    },
+    {
+      "name": "CloseThing",
+      "accounts": [
+        {
+          "name": "originalCreator",
+          "isMut": false,
+          "isSigner": true,
+          "docs": [
+            "The original creator of the thing"
+          ]
+        }
+      ],
+      "args": [],
+      "discriminant": { "type": "u8", "value": 1 }
+    }
+  ],
+  "metadata": {
+    "origin": "shank"
+  }
+}

--- a/shank-idl/tests/fixtures/instructions/single_file/instruction_with_docs.rs
+++ b/shank-idl/tests/fixtures/instructions/single_file/instruction_with_docs.rs
@@ -1,0 +1,12 @@
+#[derive(ShankInstruction)]
+pub enum Instruction {
+    #[account(0, name = "creator", sig, desc = "The creator of the thing")]
+    #[account(1, name = "thing", mut, desc = "The thing to create")]
+    CreateThing,
+    #[account(
+        name = "original_creator",
+        sig,
+        docs = "The original creator of the thing"
+    )]
+    CloseThing,
+}

--- a/shank-idl/tests/fixtures/instructions/single_file/instruction_with_optional_account_defaulting.json
+++ b/shank-idl/tests/fixtures/instructions/single_file/instruction_with_optional_account_defaulting.json
@@ -14,7 +14,7 @@
           "name": "thing",
           "isMut": true,
           "isSigner": false,
-          "optional": true
+          "isOptional": true
         }
       ],
       "args": [
@@ -25,7 +25,7 @@
           }
         }
       ],
-      "defaultOptionalAccounts": true,
+      "legacyOptionalAccountsStrategy": true,
       "discriminant": {
         "type": "u8",
         "value": 0

--- a/shank-idl/tests/fixtures/instructions/single_file/instruction_with_optional_account_defaulting.rs
+++ b/shank-idl/tests/fixtures/instructions/single_file/instruction_with_optional_account_defaulting.rs
@@ -1,6 +1,6 @@
 #[derive(ShankInstruction)]
 pub enum Instruction {
-    #[default_optional_accounts]
+    #[legacy_optional_accounts_strategy]
     #[account(0, name = "creator", sig)]
     #[account(1, name = "thing", mut, optional)]
     CreateThing(SomeArgs),

--- a/shank-idl/tests/fixtures/instructions/single_file/instruction_with_optional_signer_account.json
+++ b/shank-idl/tests/fixtures/instructions/single_file/instruction_with_optional_signer_account.json
@@ -13,8 +13,7 @@
         {
           "name": "thing",
           "isMut": true,
-          "isSigner": false,
-          "isOptional": true
+          "isSigner": false
         }
       ],
       "args": [
@@ -36,7 +35,8 @@
         {
           "name": "creator",
           "isMut": false,
-          "isSigner": true
+          "isSigner": false,
+          "isOptionalSigner": true
         }
       ],
       "args": [],

--- a/shank-idl/tests/fixtures/instructions/single_file/instruction_with_optional_signer_account.rs
+++ b/shank-idl/tests/fixtures/instructions/single_file/instruction_with_optional_signer_account.rs
@@ -1,0 +1,8 @@
+#[derive(ShankInstruction)]
+pub enum Instruction {
+    #[account(0, name = "creator", signer)]
+    #[account(1, name = "thing", writable)]
+    CreateThing(SomeArgs),
+    #[account(name = "creator", optional_signer)]
+    CloseThing,
+}

--- a/shank-idl/tests/instructions.rs
+++ b/shank-idl/tests/instructions.rs
@@ -135,3 +135,20 @@ fn instruction_from_single_file_invalid_discriminant() {
     assert!(err.contains("discriminants have to be <= u8::MAX"));
     assert!(err.contains("discriminant of variant 'CreateThing' is 256"));
 }
+
+#[test]
+fn instruction_from_single_file_with_optional_signer_account() {
+    let file = fixtures_dir()
+        .join("single_file")
+        .join("instruction_with_optional_signer_account.rs");
+    let idl = parse_file(&file, &ParseIdlConfig::optional_program_address())
+        .expect("Parsing should not fail")
+        .expect("File contains IDL");
+
+    let expected_idl: Idl = serde_json::from_str(include_str!(
+        "./fixtures/instructions/single_file/instruction_with_optional_signer_account.json"
+    ))
+    .unwrap();
+
+    assert_eq!(idl, expected_idl);
+}

--- a/shank-idl/tests/instructions.rs
+++ b/shank-idl/tests/instructions.rs
@@ -152,3 +152,20 @@ fn instruction_from_single_file_with_optional_signer_account() {
 
     assert_eq!(idl, expected_idl);
 }
+
+#[test]
+fn instruction_from_single_file_with_docs() {
+    let file = fixtures_dir()
+        .join("single_file")
+        .join("instruction_with_docs.rs");
+    let idl = parse_file(&file, &ParseIdlConfig::optional_program_address())
+        .expect("Parsing should not fail")
+        .expect("File contains IDL");
+
+    let expected_idl: Idl = serde_json::from_str(include_str!(
+        "./fixtures/instructions/single_file/instruction_with_docs.json"
+    ))
+    .unwrap();
+
+    assert_eq!(idl, expected_idl);
+}

--- a/shank-macro-impl/src/instruction/account_attrs.rs
+++ b/shank-macro-impl/src/instruction/account_attrs.rs
@@ -15,6 +15,7 @@ pub struct InstructionAccount {
     pub name: String,
     pub writable: bool,
     pub signer: bool,
+    pub optional_signer: bool,
     pub desc: Option<String>,
     pub optional: bool,
 }
@@ -68,6 +69,7 @@ impl InstructionAccount {
         let mut index: Option<u32> = None;
         let mut writable = false;
         let mut signer = false;
+        let mut optional_signer = false;
         let mut desc = None;
         let mut account_name = None;
         let mut optional = false;
@@ -101,6 +103,7 @@ impl InstructionAccount {
                         writable = true;
                     }
                     "optional" | "option" | "opt" => optional = true,
+                    "optional_signer" => optional_signer = true,
                     _ => {
                         return Err(ParseError::new_spanned(
                             ident,
@@ -123,6 +126,12 @@ impl InstructionAccount {
                 }
             }
         }
+        if signer && optional_signer {
+            return Err(ParseError::new_spanned(
+                ident,
+                "Account cannot be both signer and optional_signer",
+            ));
+        }
         match account_name {
             Some(name) => Ok(Self {
                 ident,
@@ -130,6 +139,7 @@ impl InstructionAccount {
                 name,
                 writable,
                 signer,
+                optional_signer,
                 desc,
                 optional,
             }),

--- a/shank-macro-impl/src/instruction/account_attrs.rs
+++ b/shank-macro-impl/src/instruction/account_attrs.rs
@@ -80,7 +80,7 @@ impl InstructionAccount {
             {
                 // name/desc
                 match name.as_str() {
-                    "desc" | "description" => desc = Some(value),
+                    "desc" | "description" | "docs" => desc = Some(value),
                     "name" if value.trim().is_empty() => {
                         return Err(ParseError::new_spanned(
                             ident,

--- a/shank-macro-impl/src/instruction/strategy_attrs.rs
+++ b/shank-macro-impl/src/instruction/strategy_attrs.rs
@@ -2,11 +2,12 @@ use std::collections::HashSet;
 
 use syn::Attribute;
 
-const DEFAULT_OPTIONAL_ACCOUNTS: &str = "default_optional_accounts";
+const LEGACY_OPTIONAL_ACCOUNTS_STRATEGY: &str =
+    "legacy_optional_accounts_strategy";
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub enum InstructionStrategy {
-    DefaultOptionalAccounts,
+    LegacyOptionalAccounts,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -14,12 +15,10 @@ pub struct InstructionStrategies(pub HashSet<InstructionStrategy>);
 
 impl InstructionStrategy {
     pub fn from_account_attr(attr: &Attribute) -> Option<InstructionStrategy> {
-        match attr
-            .path
-            .get_ident()
-            .map(|x| x.to_string().as_str() == DEFAULT_OPTIONAL_ACCOUNTS)
-        {
-            Some(true) => Some(InstructionStrategy::DefaultOptionalAccounts),
+        match attr.path.get_ident().map(|x| {
+            x.to_string().as_str() == LEGACY_OPTIONAL_ACCOUNTS_STRATEGY
+        }) {
+            Some(true) => Some(InstructionStrategy::LegacyOptionalAccounts),
             _ => None,
         }
     }

--- a/shank-macro-impl/src/instruction/strategy_attrs_test.rs
+++ b/shank-macro-impl/src/instruction/strategy_attrs_test.rs
@@ -27,11 +27,11 @@ fn parse_first_enum_variant_attrs(
 }
 
 #[test]
-fn instruction_with_default_optional_accounts() {
+fn instruction_with_legacy_optional_accounts_strategy() {
     let (accounts, strategies) = parse_first_enum_variant_attrs(quote! {
         #[derive(ShankInstruction)]
         pub enum Instructions {
-            #[default_optional_accounts]
+            #[legacy_optional_accounts_strategy]
             #[account(name="authority")]
             NonIndexed
         }
@@ -54,13 +54,13 @@ fn instruction_with_default_optional_accounts() {
     assert!(
         strategies
             .0
-            .contains(&InstructionStrategy::DefaultOptionalAccounts),
-        "to default optional accounts"
+            .contains(&InstructionStrategy::LegacyOptionalAccounts),
+        "to legacy optional accounts strategy"
     );
 }
 
 #[test]
-fn instruction_without_default_optional_accounts() {
+fn instruction_without_legacy_optional_accounts_strategy() {
     let (accounts, strategies) = parse_first_enum_variant_attrs(quote! {
         #[derive(ShankInstruction)]
         pub enum Instructions {

--- a/shank-macro/src/lib.rs
+++ b/shank-macro/src/lib.rs
@@ -110,7 +110,7 @@ pub fn shank_account(input: TokenStream) -> TokenStream {
 ///   mutated as part of processing the particular instruction
 /// - `optional | option | opt`: indicates that this account is optional
 /// - `name`: (required) provides the name for the account
-/// - `desc` | `description`: allows to provide a description of the account
+/// - `desc` | `description` | `docs`: allows to provide a description of the account
 ///
 /// When the `optional` attribute is added to an account, shank will mark it such that its value should default
 /// to the `progam_id` if it is not provided by the client. Thus the position of optional accounts is static and

--- a/shank-macro/src/lib.rs
+++ b/shank-macro/src/lib.rs
@@ -111,6 +111,10 @@ pub fn shank_account(input: TokenStream) -> TokenStream {
 /// - `name`: (required) provides the name for the account
 /// - `desc` | `description`: allows to provide a description of the account
 ///
+/// When the `optional` attribute is added to an account, shank will mark it such that its value should default
+/// to the `progam_id` if it is not provided by the client. Thus the position of optional accounts is static and
+/// optional accounts that are set can follow ones that are not.
+///
 /// # Known Accounts
 ///
 /// If an account `name` matches either of the a _known_ accounts indicated below then
@@ -124,19 +128,16 @@ pub fn shank_account(input: TokenStream) -> TokenStream {
 ///
 /// # Strategies
 ///
-/// ## Defaulting Optional Accounts
+/// ## Legacy Optional Accounts Strategy
 ///
-/// When the `#[default_optional_accounts]` attribute is added to an Instruction enum, shank will mark it
-/// such that optional accounts should default to the `progam_id` if they are not provided by the client.
-/// Thus their position is static and optional accounts that are set can follow ones that are not.
-///
-/// The default strategy (without `#[default_optional_accounts]`) is to just omit unset optional
-/// accounts from the accounts array.
+/// The default strategy (without `#[legacy_optional_accounts_strategy]`) is to set the `program_id` in place
+/// of an optional account not set by the client. When the `#[legacy_optional_accounts_strategy]` is added,
+/// shank will instead omit unset optional accounts from the accounts array.
 ///
 /// **NOTE**: shank doesn't do anything different here aside from setting a flag for the
 /// particular instruction. Thus adding that strategy to an instruction enum is merely advisory and
 /// will is expected to be properly respected by code generator tools like
-/// [solita](https://github.com/metaplex-foundation/solita).
+/// [kinobi](https://github.com/metaplex-foundation/kinobi) and [solita](https://github.com/metaplex-foundation/solita).
 ///
 /// # Examples
 ///
@@ -178,7 +179,7 @@ pub fn shank_account(input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro_derive(
     ShankInstruction,
-    attributes(account, default_optional_accounts)
+    attributes(account, legacy_optional_accounts_strategy)
 )]
 pub fn shank_instruction(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/shank-macro/src/lib.rs
+++ b/shank-macro/src/lib.rs
@@ -99,12 +99,13 @@ pub fn shank_account(input: TokenStream) -> TokenStream {
 /// They take the following general form:
 ///
 /// ```
-/// #[account(index?, (writable|signer)?, optional?, name="<account_name>", desc?="optional description")]
+/// #[account(index?, writable?, (signer|optional_signer)?, optional?, name="<account_name>", desc?="optional description")]
 /// ```
 ///
 /// - `index`: optionally provides the account index in the provided accounts array which needs to
 ///   match its position of `#[account]` attributes
 /// - `signer` | `sign` | `sig`: indicates that the account is _signer_
+/// - `optional_signer`: indicates that the account is _optional_signer_
 /// - `writable` | `write` | `writ` | `mut`: indicates that the account is _writable_ which means it may be
 ///   mutated as part of processing the particular instruction
 /// - `optional | option | opt`: indicates that this account is optional
@@ -156,7 +157,7 @@ pub fn shank_account(input: TokenStream) -> TokenStream {
 ///             desc = "Initialized fraction treasury token account with 0 tokens in supply, owner of account must be pda of program like above")]
 ///     #[account(3, writable, name="vault",
 ///             desc = "Uninitialized vault account")]
-///     #[account(4, name="authority",
+///     #[account(4, optional_signer, name="authority",
 ///             desc = "Authority on the vault")]
 ///     #[account(5, name="pricing_lookup_address",
 ///             desc = "Pricing Lookup Address")]


### PR DESCRIPTION
This PR improves the IDL output of shank:
1. The `desc` IDL field is renamed to `docs`.
2. The `optional` field is renamed to `isOptional`.

These changes make shank generated IDL closer to Anchor format. Additionally, it renames the `default_optional_accounts` tag to `legacy_optional_accounts_strategy`. With this change, the default behaviour is to replace missing optional accounts with the program id, unless the  `legacy_optional_accounts_strategy` attribute is used.

Finally, it includes a new attribute on the account annotation: `optional_signer`. This can be use instead of `signer` to indicate that the account is an optional signer. When `optional_signer` is given, `isSigner` will be set to `false` on the IDL and a new `isOptionalSigner` attribute will be set to `true`.