### PR TITLE
Add shank type macro

### DIFF
--- a/shank-idl/tests/fixtures/types/valid_single_enum_shank_type.json
+++ b/shank-idl/tests/fixtures/types/valid_single_enum_shank_type.json
@@ -1,0 +1,33 @@
+{
+  "version": "",
+  "name": "",
+  "instructions": [],
+  "types": [
+    {
+      "name": "Color",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Red",
+            "fields": ["u8"]
+          },
+          {
+            "name": "Green",
+            "fields": ["u8"]
+          },
+          {
+            "name": "Blue",
+            "fields": ["u8"]
+          },
+          {
+            "name": "White"
+          }
+        ]
+      }
+    }
+  ],
+  "metadata": {
+    "origin": "shank"
+  }
+}

--- a/shank-idl/tests/fixtures/types/valid_single_enum_shank_type.rs
+++ b/shank-idl/tests/fixtures/types/valid_single_enum_shank_type.rs
@@ -1,0 +1,7 @@
+#[derive(ShankType)]
+pub enum Color {
+    Red(u8),
+    Green(u8),
+    Blue(u8),
+    White,
+}

--- a/shank-idl/tests/fixtures/types/valid_single_struct_shank_type.json
+++ b/shank-idl/tests/fixtures/types/valid_single_struct_shank_type.json
@@ -1,0 +1,22 @@
+{
+  "version": "",
+  "name": "",
+  "instructions": [],
+  "types": [
+    {
+      "name": "MyType",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "field",
+            "type": "u8"
+          }
+        ]
+      }
+    }
+  ],
+  "metadata": {
+    "origin": "shank"
+  }
+}

--- a/shank-idl/tests/fixtures/types/valid_single_struct_shank_type.rs
+++ b/shank-idl/tests/fixtures/types/valid_single_struct_shank_type.rs
@@ -1,0 +1,4 @@
+#[derive(ShankType)]
+pub struct MyType {
+    pub field: u8,
+}

--- a/shank-idl/tests/types.rs
+++ b/shank-idl/tests/types.rs
@@ -123,3 +123,35 @@ fn type_valid_tuples() {
 
     assert_eq!(idl, expected_idl);
 }
+
+#[test]
+fn type_valid_single_struct_shank_type() {
+    let file = fixtures_dir().join("valid_single_struct_shank_type.rs");
+    let idl = parse_file(&file, &ParseIdlConfig::optional_program_address())
+        .expect("Parsing should not fail")
+        .expect("File contains IDL");
+    // eprintln!("{}", serde_json::to_string_pretty(&idl).unwrap());
+
+    let expected_idl: Idl = serde_json::from_str(include_str!(
+        "./fixtures/types/valid_single_struct_shank_type.json"
+    ))
+    .unwrap();
+
+    assert_eq!(idl, expected_idl);
+}
+
+#[test]
+fn type_valid_single_enum_shank_type() {
+    let file = fixtures_dir().join("valid_single_enum_shank_type.rs");
+    let idl = parse_file(&file, &ParseIdlConfig::optional_program_address())
+        .expect("Parsing should not fail")
+        .expect("File contains IDL");
+    // eprintln!("{}", serde_json::to_string_pretty(&idl).unwrap());
+
+    let expected_idl: Idl = serde_json::from_str(include_str!(
+        "./fixtures/types/valid_single_enum_shank_type.json"
+    ))
+    .unwrap();
+
+    assert_eq!(idl, expected_idl);
+}

--- a/shank-macro-impl/src/custom_type/custom_struct.rs
+++ b/shank-macro-impl/src/custom_type/custom_struct.rs
@@ -96,4 +96,25 @@ mod tests {
             struct MyStruct {}
         });
     }
+
+    #[test]
+    fn is_custom_struct_including_borsh_derive_and_shank_type() {
+        assert_is_custom(quote! {
+            #[derive(BorshSerialize, ShankType)]
+            struct MyStruct {}
+        });
+        assert_is_custom(quote! {
+            #[derive(BorshSerialize)]
+            #[derive(ShankType)]
+            struct MyStruct {}
+        });
+    }
+
+    #[test]
+    fn is_custom_struct_including_shank_type() {
+        assert_is_custom(quote! {
+            #[derive(ShankType)]
+            struct MyStruct {}
+        });
+    }
 }

--- a/shank-macro-impl/src/custom_type/custom_type_config.rs
+++ b/shank-macro-impl/src/custom_type/custom_type_config.rs
@@ -19,7 +19,7 @@ impl Default for DetectCustomTypeConfig {
     fn default() -> Self {
         Self {
             include_derives: HashSet::from_iter(
-                vec!["BorshSerialize", "BorshDeserialize"]
+                vec!["BorshSerialize", "BorshDeserialize", "ShankType"]
                     .into_iter()
                     .map(String::from),
             ),

--- a/shank-macro/src/lib.rs
+++ b/shank-macro/src/lib.rs
@@ -74,7 +74,7 @@ mod instruction;
 ///# Note
 ///
 /// The fields of a _ShankAccount_ struct can reference other types as long as they are annotated
-/// with `BorshSerialize` or `BorshDeserialize`.
+/// with `ShankType`, `BorshSerialize` or `BorshDeserialize`.
 #[proc_macro_derive(ShankAccount, attributes(padding, seeds))]
 pub fn shank_account(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -127,9 +127,7 @@ pub fn shank_account(input: TokenStream) -> TokenStream {
 /// - `system_program` uses `SystemProgram.programId`
 /// - `rent` uses `SYSVAR_RENT_PUBKEY`
 ///
-/// # Strategies
-///
-/// ## Legacy Optional Accounts Strategy
+/// # Optional Accounts Strategies
 ///
 /// The default strategy (without `#[legacy_optional_accounts_strategy]`) is to set the `program_id` in place
 /// of an optional account not set by the client. When the `#[legacy_optional_accounts_strategy]` is added,
@@ -292,6 +290,39 @@ pub fn shank_context(input: TokenStream) -> TokenStream {
     derive_context(input)
         .unwrap_or_else(to_compile_error)
         .into()
+}
+
+// -----------------
+// #[derive(ShankType)]
+// -----------------
+
+/// Annotates a _struct_ or _enum_ that shank will consider a type containing de/serializable data.
+///
+/// The macro does not generate any code. The annotation is used to indicate to shank-idl that the
+/// the type should be included in the program's IDL.
+///
+/// # Example
+///
+/// ```
+/// use shank::ShankType;
+///
+/// #[derive(ShankType)]
+/// pub struct Metadata {
+///     pub update_authority: Pubkey,
+///     pub mint: Pubkey,
+///     pub primary_sale_happened: bool,
+/// }
+/// ```
+///
+///# Note
+///
+/// The fields of a _ShankType_ struct or enum can reference other types as long as they are annotated
+/// with `ShankType`, `BorshSerialize` or `BorshDeserialize`.
+#[proc_macro_derive(ShankType)]
+pub fn shank_type(input: TokenStream) -> TokenStream {
+    // returns the token stream that was passed in (the macro is only an annotation for shank-idl
+    // to export the type in the program's IDL)
+    input
 }
 
 fn to_compile_error(error: ParseError) -> proc_macro2::TokenStream {


### PR DESCRIPTION
This PR adds `ShankType` macro annotation. The macro does not generate any code. The annotation is used to indicate to `shank-idl` that the the type should be included in the program's IDL.

Fixes #28 