### PR TITLE
Improve shank context code generation

### DIFF
--- a/shank-macro/src/lib.rs
+++ b/shank-macro/src/lib.rs
@@ -240,11 +240,12 @@ pub fn shank_builder(input: TokenStream) -> TokenStream {
 // #[derive(ShankContext)]
 // -----------------
 
-/// Generates a context _struct_ for each instruction.
+/// Generates an accounts _struct_ for each instruction.
 ///
 /// The _struct_ will contain all shank annotated accounts and the _impl_ block
-/// will initialize them using the accounts iterator. It support the use of
-/// optional accounts, which would generate an account field with an
+/// will initialize them from the accounts array. This struct can be used in combination
+/// with a `Context` to provide access to accounts by name. The accounts _strct_ supports
+///  the use of optional accounts, which would generate an account field with an
 /// `Option<AccountInfo<'a>>` type.
 ///
 /// # Example
@@ -267,8 +268,8 @@ pub fn shank_builder(input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// A generic `Context` _struct_ will be generated, which can be used to access each account in
-/// your processor implementation:
+/// A `CreateAccounts` and a generic `Context` _structs_ will be generated, which can be used to
+/// access each account by name in your processor implementation:
 ///
 /// ```
 /// pub fn process_create<'a>(
@@ -276,7 +277,7 @@ pub fn shank_builder(input: TokenStream) -> TokenStream {
 ///     accounts: &'a [AccountInfo<'a>],
 ///     instruction_data: &[u8],
 /// ) -> ProgramResult {
-///     let context = Create::to_context(accounts)?;
+///     let context = CreateAccounts::context(accounts)?;
 ///
 ///     msg!("{}", context.accounts.vault.key);
 ///     msg!("{}", context.accounts.authority.key);

--- a/shank-render/src/context/mod.rs
+++ b/shank-render/src/context/mod.rs
@@ -16,29 +16,15 @@ pub fn render_contexts_impl(
         .collect::<Vec<TokenStream>>();
 
     Ok(quote! {
-        /// Convenience function for accessing the next item in an [`AccountInfo`]
-        /// iterator and validating whether the account is present or not.
-        ///
-        /// This relies on the client setting the `crate::ID` as the pubkey for
-        /// accounts that are not set, which effectively allows us to use positional
-        /// optional accounts.
-        fn next_optional_account_info<'b, 'c, I: Iterator<Item = &'b solana_program::account_info::AccountInfo<'c>>>(
-            iter: &mut I,
-        ) -> Result<Option<I::Item>, solana_program::program_error::ProgramError> {
-            let account_info = iter.next().ok_or(solana_program::program_error::ProgramError::NotEnoughAccountKeys)?;
+        pub mod accounts {
+            use super::*;
 
-            Ok(if *account_info.key == crate::ID {
-                None
-            } else {
-                Some(account_info)
-            })
+            pub struct Context<'a, T> {
+                pub accounts: T,
+                pub remaining_accounts: &'a [solana_program::account_info::AccountInfo<'a>],
+            }
+
+            #(#contexts)*
         }
-
-        pub struct Context<'a, T> {
-            pub accounts: T,
-            pub remaining_accounts: Vec<&'a solana_program::account_info::AccountInfo<'a>>,
-        }
-
-        #(#contexts)*
     })
 }


### PR DESCRIPTION
This PR improves the `ShankContext` macro code generation:
1. the generated code is now placed in an `accounts` submodule;
2. the struct is renamed to "*InstructionName*Accounts" to avoid name clashes