### PR TITLE
Fix comments generated by ShankAccount seeds

### DIFF
--- a/shank-render/src/pda/mod.rs
+++ b/shank-render/src/pda/mod.rs
@@ -43,7 +43,7 @@ pub fn render_pda_and_seeds_impl(
         &pda_fn_ident,
         &pda_fn_with_bump_ident,
         include_comments,
-    );
+    )?;
 
     if let (Some(pub_seeds_fn), Some(pub_pda_fn)) = (pub_seeds_fn, pub_pda_fn) {
         Ok(quote! {

--- a/shank-render/src/pda/render_seeds.rs
+++ b/shank-render/src/pda/render_seeds.rs
@@ -1,4 +1,4 @@
-use quote::{quote, ToTokens};
+use quote::quote;
 use std::str::FromStr;
 
 use proc_macro2::{Ident, Span, TokenStream};
@@ -40,23 +40,21 @@ pub fn try_render_seeds_fn(
     let (seeds_comments, seeds_with_bump_comments) = if include_comments {
         let args_comments = render_args_comments(processed_seeds, false);
         (
-            format!(
+            TokenStream::from_str(&format!(
                 r#"
                 /// Derives the seeds for this account.
                 ///
                 {}"#,
                 args_comments.join("\n")
-            )
-            .to_token_stream(),
-            format!(
+            ))?,
+            TokenStream::from_str(&format!(
                 r#"
                 /// Derives the seeds for this account allowing to provide a bump seed.
                 ///
                 {}
                 /// * **bump**: the bump seed to pass when deriving the PDA"#,
                 args_comments.join("\n")
-            )
-            .to_token_stream(),
+            ))?,
         )
     } else {
         (TokenStream::new(), TokenStream::new())

--- a/shank-render/tests/pda/render_impl.rs
+++ b/shank-render/tests/pda/render_impl.rs
@@ -177,9 +177,7 @@ fn candy_guard_mint_limit_impl() {
 // Including Comments
 // -----------------
 
-// NOTE: once comments are involved it is very brittle to compare rendered code
-//       thus this test only exists to allow uncommenting dumping the rendered code
-// #[test]
+#[test]
 #[allow(unused)]
 fn literal_pubkeys_and_u8_byte_impl_commented() {
     let code = quote! {

--- a/shank-render/tests/pda/render_pda_fn.rs
+++ b/shank-render/tests/pda/render_pda_fn.rs
@@ -21,6 +21,7 @@ fn render_pda(code: TokenStream, include_comments: bool) -> TokenStream {
         include_comments,
     )
     .unwrap()
+    .unwrap()
 }
 
 #[allow(unused)]

--- a/shank-render/tests/utils/mod.rs
+++ b/shank-render/tests/utils/mod.rs
@@ -28,6 +28,5 @@ pub fn process_seeds(code: TokenStream) -> ParseResult<Vec<ProcessedSeed>> {
 }
 
 pub fn pretty_print(code: TokenStream) -> String {
-    let syn_tree = syn::parse_file(code.to_string().as_str()).unwrap();
-    prettyplease::unparse(&syn_tree)
+    prettyplease::unparse(&syn::parse2(code).unwrap())
 }


### PR DESCRIPTION
Comments were being interpreted as string literals in generated code instead of as comments.