### PR TITLE
Remove debug messages

### DIFF
--- a/shank-idl/src/idl_type.rs
+++ b/shank-idl/src/idl_type.rs
@@ -66,7 +66,7 @@ impl TryFrom<RustType> for IdlType {
                 }
             },
             TypeKind::Composite(kind, inners) => match kind {
-                Composite::Vec => match inners.get(0).cloned() {
+                Composite::Vec => match inners.first().cloned() {
                     Some(inner) => {
                         let inner_idl: IdlType = inner.try_into()?;
                         if inner_idl == IdlType::U8 {
@@ -80,7 +80,7 @@ impl TryFrom<RustType> for IdlType {
                         anyhow::bail!("Rust Vec Composite needs inner type")
                     }
                 },
-                Composite::Array(size) => match inners.get(0).cloned() {
+                Composite::Array(size) => match inners.first().cloned() {
                     Some(inner) => {
                         let inner_idl: IdlType = inner.try_into()?;
                         IdlType::Array(Box::new(inner_idl), size)
@@ -90,7 +90,7 @@ impl TryFrom<RustType> for IdlType {
                     }
                 },
 
-                Composite::Option => match inners.get(0).cloned() {
+                Composite::Option => match inners.first().cloned() {
                     Some(inner) => {
                         let inner_idl: IdlType = inner.try_into()?;
                         IdlType::Option(Box::new(inner_idl))
@@ -109,7 +109,7 @@ impl TryFrom<RustType> for IdlType {
                     }
                 }
                 Composite::HashMap => {
-                    match (inners.get(0).cloned(), inners.get(1).cloned()) {
+                    match (inners.first().cloned(), inners.get(1).cloned()) {
                         (Some(inner1), Some(inner2)) => {
                             let inner1_idl: IdlType = inner1.try_into()?;
                             let inner2_idl: IdlType = inner2.try_into()?;
@@ -126,7 +126,7 @@ impl TryFrom<RustType> for IdlType {
                     }
                 }
                 Composite::BTreeMap => {
-                    match (inners.get(0).cloned(), inners.get(1).cloned()) {
+                    match (inners.first().cloned(), inners.get(1).cloned()) {
                         (Some(inner1), Some(inner2)) => {
                             let inner1_idl: IdlType = inner1.try_into()?;
                             let inner2_idl: IdlType = inner2.try_into()?;
@@ -142,7 +142,7 @@ impl TryFrom<RustType> for IdlType {
                         }
                     }
                 }
-                Composite::HashSet => match inners.get(0).cloned() {
+                Composite::HashSet => match inners.first().cloned() {
                     Some(inner) => {
                         let inner_idl: IdlType = inner.try_into()?;
                         IdlType::HashSet(Box::new(inner_idl))
@@ -153,7 +153,7 @@ impl TryFrom<RustType> for IdlType {
                         )
                     }
                 },
-                Composite::BTreeSet => match inners.get(0).cloned() {
+                Composite::BTreeSet => match inners.first().cloned() {
                     Some(inner) => {
                         let inner_idl: IdlType = inner.try_into()?;
                         IdlType::BTreeSet(Box::new(inner_idl))
@@ -185,7 +185,7 @@ mod tests {
 
     #[test]
     fn idl_from_rust_type_primivives() {
-        for (rust_prim, idl_expected) in vec![
+        for (rust_prim, idl_expected) in [
             (Primitive::U8, IdlType::U8),
             (Primitive::U16, IdlType::U16),
             (Primitive::I128, IdlType::I128),

--- a/shank-macro-impl/src/builder/builder.rs
+++ b/shank-macro-impl/src/builder/builder.rs
@@ -97,7 +97,7 @@ impl TryFrom<&ParsedEnumVariant> for BuilderVariant {
 
         let field_tys: InstructionVariantFields = if !fields.is_empty() {
             // Determine if the InstructionType is tuple or struct variant
-            let field = fields.get(0).unwrap();
+            let field = fields.first().unwrap();
             match &field.ident {
                 Some(_) => InstructionVariantFields::Named(
                     fields

--- a/shank-macro-impl/src/instruction/idl_instruction_attrs.rs
+++ b/shank-macro-impl/src/instruction/idl_instruction_attrs.rs
@@ -293,14 +293,14 @@ impl TryFrom<&[Attribute]> for IdlInstruction {
         if idl_instructions.len() > 1 {
             Err(IdlInstructionError::TooManyIdlInstructions(
                 ParseError::new_spanned(
-                    attrs.get(0),
+                    attrs.first(),
                     "Only one #[idl_instruction] attr is allowed per instruction",
                 ),
             ))
         } else if idl_instructions.is_empty() {
             Err(IdlInstructionError::NotEnoughIdlInstructions)
         } else {
-            let ix = *idl_instructions.get(0).unwrap();
+            let ix = *idl_instructions.first().unwrap();
             Ok(ix)
         }
     }

--- a/shank-macro-impl/src/instruction/instruction.rs
+++ b/shank-macro-impl/src/instruction/instruction.rs
@@ -130,24 +130,16 @@ impl TryFrom<&ParsedEnumVariant> for InstructionVariant {
         };
 
         let attrs: &[Attribute] = attrs.as_ref();
-        let accounts: InstructionAccounts;
-        let strategies: InstructionStrategies;
-
-        let idl_instruction = IdlInstruction::try_from(attrs);
-        match idl_instruction {
+        let (accounts, strategies) = match IdlInstruction::try_from(attrs) {
             Ok(idl_ix) => {
-                accounts = idl_ix.to_accounts(ident.clone());
                 field_tys = idl_ix.to_instruction_fields(ident.clone());
-                strategies = InstructionStrategies(HashSet::<
-                    InstructionStrategy,
-                >::new());
+                (
+                    idl_ix.to_accounts(ident.clone()),
+                    InstructionStrategies(HashSet::<InstructionStrategy>::new()),
+                )
             }
-            Err(err) => {
-                println!("{}", err);
-                accounts = attrs.try_into()?;
-                strategies = attrs.into();
-            }
-        }
+            Err(_) => (attrs.try_into()?, attrs.into()),
+        };
 
         Ok(Self {
             ident: ident.clone(),

--- a/shank-macro-impl/src/instruction/instruction.rs
+++ b/shank-macro-impl/src/instruction/instruction.rs
@@ -14,8 +14,8 @@ use crate::{
 };
 
 use super::{
-    account_attrs::{InstructionAccount, InstructionAccounts},
-    IdlInstruction, InstructionStrategies, InstructionStrategy,
+    account_attrs::InstructionAccount, IdlInstruction, InstructionStrategies,
+    InstructionStrategy,
 };
 
 // -----------------
@@ -108,7 +108,7 @@ impl TryFrom<&ParsedEnumVariant> for InstructionVariant {
 
         let mut field_tys: InstructionVariantFields = if !fields.is_empty() {
             // Determine if the InstructionType is tuple or struct variant
-            let field = fields.get(0).unwrap();
+            let field = fields.first().unwrap();
             match &field.ident {
                 Some(_) => InstructionVariantFields::Named(
                     fields

--- a/shank-macro-impl/src/parsed_struct/parsed_struct_test.rs
+++ b/shank-macro-impl/src/parsed_struct/parsed_struct_test.rs
@@ -42,7 +42,7 @@ fn match_array_field(
         assert_eq!(ident, field_ident);
         assert_eq!(rust_type.ident, "Array");
         assert_matches!(&rust_type.kind, TypeKind::Composite(Composite::Array(array_size), inner)  => {
-            let inner_rust_ty = inner.get(0).expect("array should have inner type");
+            let inner_rust_ty = inner.first().expect("array should have inner type");
             assert_eq!(inner_rust_ty.ident, inner_ty, "inner array type");
             assert_eq!(*array_size, size, "array size");
         });
@@ -60,7 +60,7 @@ fn match_array_field_with_attrs(
         assert_eq!(ident, field_ident);
         assert_eq!(rust_type.ident, "Array");
         assert_matches!(&rust_type.kind, TypeKind::Composite(Composite::Array(array_size), inner)  => {
-            let inner_rust_ty = inner.get(0).expect("array should have inner type");
+            let inner_rust_ty = inner.first().expect("array should have inner type");
             assert_eq!(inner_rust_ty.ident, inner_ty, "inner array type");
             assert_eq!(*array_size, size, "array size");
         });

--- a/shank-macro-impl/src/types/mod.rs
+++ b/shank-macro-impl/src/types/mod.rs
@@ -3,6 +3,5 @@ mod render_rust_ty;
 mod resolve_rust_ty;
 mod type_kind;
 pub use parsed_reference::*;
-pub use render_rust_ty::*;
 pub use resolve_rust_ty::*;
 pub use type_kind::*;

--- a/shank-macro-impl/src/types/resolve_rust_ty.rs
+++ b/shank-macro-impl/src/types/resolve_rust_ty.rs
@@ -392,7 +392,6 @@ pub fn resolve_rust_ty(
         }
     };
 
-    println!("[resolve_rust_ty] {:?}: {:?}", ident, kind);
     Ok(RustType {
         ident,
         kind,

--- a/shank-macro-impl/src/types/type_kind.rs
+++ b/shank-macro-impl/src/types/type_kind.rs
@@ -111,7 +111,7 @@ impl TypeKind {
             | TypeKind::Composite(Composite::Array(_), inners)
             | TypeKind::Composite(Composite::HashSet, inners)
             | TypeKind::Composite(Composite::BTreeSet, inners) => {
-                inners.get(0).cloned()
+                inners.first().cloned()
             }
             TypeKind::Composite(_, _) => None,
             TypeKind::Unit => None,
@@ -127,7 +127,7 @@ impl TypeKind {
             TypeKind::Value(_) => (None, None),
             TypeKind::Composite(Composite::HashMap, inners)
             | TypeKind::Composite(Composite::BTreeMap, inners) => {
-                (inners.get(0).cloned(), inners.get(1).cloned())
+                (inners.first().cloned(), inners.get(1).cloned())
             }
             TypeKind::Composite(_, _) => (None, None),
             TypeKind::Unit => (None, None),
@@ -144,7 +144,7 @@ impl TypeKind {
                     || composite == &Composite::BTreeMap =>
             {
                 let key = inners
-                    .get(0)
+                    .first()
                     .cloned()
                     .ok_or_else(|| {
                         format!("{:?} should have key type", composite)


### PR DESCRIPTION
This PR removes debug error messages, which might confuse users since they suggest that something went wrong on the IDL generation. These were introduced with the new `idl_instruction` attribute.

Debug error messages currently being displayed (and removed by this PR):
```
[resolve_rust_ty] Ident(Metadata): TypeKind::Value(Value::Custom("Metadata"))
[resolve_rust_ty] Ident(DelegateInput): TypeKind::Value(Value::Custom("DelegateInput"))
[resolve_rust_ty] Ident(Extension): TypeKind::Value(Value::Custom("Extension"))
[resolve_rust_ty] Ident(DelegateInput): TypeKind::Value(Value::Custom("DelegateInput"))
[resolve_rust_ty] Ident(UpdateInput): TypeKind::Value(Value::Custom("UpdateInput"))
[resolve_rust_ty] Ident(Data): TypeKind::Value(Value::Custom("Data"))
no #[idl_instruction] attributes found
no #[idl_instruction] attributes found
no #[idl_instruction] attributes found
no #[idl_instruction] attributes found
no #[idl_instruction] attributes found
no #[idl_instruction] attributes found
no #[idl_instruction] attributes found
no #[idl_instruction] attributes found
no #[idl_instruction] attributes found
no #[idl_instruction] attributes found
no #[idl_instruction] attributes found
no #[idl_instruction] attributes found
no #[idl_instruction] attributes found
no #[idl_instruction] attributes found
no #[idl_instruction] attributes found
[resolve_rust_ty] Ident(String): TypeKind::Value(Value::String)
[resolve_rust_ty] Ident(Standard): TypeKind::Value(Value::Custom("Standard"))
[resolve_rust_ty] Ident(bool): TypeKind::Primitive(Primitive::Bool)
[resolve_rust_ty] Ident(ExtensionType): TypeKind::Value(Value::Custom("ExtensionType"))
[resolve_rust_ty] Ident(u32): TypeKind::Primitive(Primitive::U32)
[resolve_rust_ty] Ident(u8): TypeKind::Primitive(Primitive::U8)
[resolve_rust_ty] Ident(Vec): TypeKind::Composite(Composite::Vec, [RustType { ident: Ident(u8), kind: TypeKind::Primitive(Primitive::U8), reference: ParsedReference::Owned, context: CollectionItem }])
[resolve_rust_ty] Ident(Option): TypeKind::Composite(Composite::Option, [RustType { ident: Ident(Vec), kind: TypeKind::Composite(Composite::Vec, [RustType { ident: Ident(u8), kind: TypeKind::Primitive(Primitive::U8), reference: ParsedReference::Own
```

It also fixes clippy warnings.