### PR TITLE
Skip and rename for Shank types and account fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Shank is a collection of Rust crates that extract Interface Definition Language (IDL) files from Solana programs using macro annotations. The generated IDL is consumed by tools like [solita](https://github.com/metaplex-foundation/solita) to generate TypeScript SDKs for Solana programs.
+
+## Architecture
+
+This is a Rust workspace containing 6 main crates:
+
+- **shank** - Top-level crate that exports all macros, entry point for users
+- **shank-macro** - Provides derive macros (`ShankAccount`, `ShankInstruction`, `ShankType`, etc.)
+- **shank-macro-impl** - Core implementation of the derive macros and parsing logic
+- **shank-idl** - Processes Rust source files to extract IDL from shank annotations
+- **shank-render** - Generates Rust code (like PDA functions) from annotations
+- **shank-cli** - Command-line tool that orchestrates IDL extraction
+
+The workflow: Users annotate their Solana program structs/enums with shank macros → shank-cli analyzes the source code → produces JSON IDL → consumed by code generators.
+
+## Common Commands
+
+### Building and Testing
+```bash
+cargo test                    # Run all tests across workspace
+cargo build                   # Build all crates
+cargo build --release         # Release build
+```
+
+### CLI Usage
+```bash
+cargo install shank-cli       # Install CLI globally
+shank idl                     # Extract IDL to ./idl/ directory
+shank idl -o <dir>            # Extract IDL to custom directory
+shank idl -r <crate-root>     # Specify program crate root
+```
+
+### Release Process
+```bash
+cargo test && cargo release <major|minor|patch>     # Dry run
+cargo release <major|minor|patch> --execute         # Execute release
+```
+
+## Key Macro Annotations
+
+- `#[derive(ShankAccount)]` - Marks account structs with optional `#[seeds]` for PDA generation
+- `#[derive(ShankInstruction)]` - Marks instruction enums with `#[account]` attributes
+- `#[derive(ShankType)]` - Marks custom types for IDL inclusion
+- `#[derive(ShankBuilder)]` - Generates instruction builders 
+- `#[derive(ShankContext)]` - Generates account context structs
+
+### Field Attributes
+
+- `#[padding]` - Marks field as padding in IDL
+- `#[idl_type("TypeName")]` - Overrides field type in IDL
+- `#[idl_name("name")]` - Renames field in IDL while keeping Rust field name
+- `#[skip]` - Excludes field from IDL entirely
+
+## Testing
+
+Test files are organized in each crate's `tests/` directory with fixture files demonstrating expected behavior. Tests verify both macro expansion and IDL generation accuracy.
+
+## Development Notes
+
+- Uses Rust 2018 edition
+- Release configuration in `release.toml` 
+- Only releases from `master` branch
+- Uses `rustfmt.toml` for consistent formatting
+- Heavy use of `syn` and `quote` for macro implementation

--- a/shank-idl/src/idl_field.rs
+++ b/shank-idl/src/idl_field.rs
@@ -19,6 +19,13 @@ pub struct IdlField {
 impl TryFrom<StructField> for IdlField {
     type Error = Error;
     fn try_from(field: StructField) -> Result<Self> {
+        // Use the overridden name if present, otherwise use the field name
+        let name = if let Some(override_name) = field.name_override() {
+            override_name.clone()
+        } else {
+            field.ident.to_string().to_mixed_case()
+        };
+
         let ty: IdlType = if let Some(override_type) = field.type_override() {
             override_type.clone().try_into()?
         } else {
@@ -32,10 +39,6 @@ impl TryFrom<StructField> for IdlField {
             .collect::<Vec<String>>();
 
         let attrs = if attrs.is_empty() { None } else { Some(attrs) };
-        Ok(Self {
-            name: field.ident.to_string().to_mixed_case(),
-            ty,
-            attrs,
-        })
+        Ok(Self { name, ty, attrs })
     }
 }

--- a/shank-idl/src/idl_type_definition.rs
+++ b/shank-idl/src/idl_type_definition.rs
@@ -27,6 +27,7 @@ impl TryFrom<ParsedStruct> for IdlTypeDefinitionTy {
         let fields = strct
             .fields
             .into_iter()
+            .filter(|field| !field.is_skipped()) // Filter out skipped fields
             .map(IdlField::try_from)
             .collect::<Result<Vec<IdlField>>>()?;
 

--- a/shank-idl/tests/accounts.rs
+++ b/shank-idl/tests/accounts.rs
@@ -77,6 +77,16 @@ fn account_from_single_file_idl_type() {
 }
 
 #[test]
+fn account_from_single_file_field_attributes() {
+    let file = fixtures_dir().join("single_file").join("field_attributes.rs");
+    let idl = parse_file(file, &ParseIdlConfig::optional_program_address())
+        .expect("Parsing should not fail")
+        .expect("File contains IDL");
+
+    check_or_update_idl(&idl, "single_file/field_attributes.json");
+}
+
+#[test]
 fn account_from_crate() {
     let file = fixtures_dir()
         .join("sample_crate")

--- a/shank-idl/tests/fixtures/accounts/single_file/field_attributes.json
+++ b/shank-idl/tests/fixtures/accounts/single_file/field_attributes.json
@@ -1,0 +1,50 @@
+{
+  "version": "",
+  "name": "",
+  "instructions": [],
+  "accounts": [
+    {
+      "name": "FieldAttributesExample",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "normalField",
+            "type": "u64"
+          },
+          {
+            "name": "customName",
+            "type": "string",
+            "attrs": [
+              "idl-name"
+            ]
+          },
+          {
+            "name": "renamedAndPadded",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            },
+            "attrs": [
+              "idl-name",
+              "padding"
+            ]
+          },
+          {
+            "name": "customTypedField",
+            "type": "u32",
+            "attrs": [
+              "idl-type",
+              "idl-name"
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "metadata": {
+    "origin": "shank"
+  }
+}

--- a/shank-idl/tests/fixtures/accounts/single_file/field_attributes.rs
+++ b/shank-idl/tests/fixtures/accounts/single_file/field_attributes.rs
@@ -1,0 +1,22 @@
+use shank::ShankAccount;
+
+#[derive(ShankAccount)]
+pub struct FieldAttributesExample {
+    pub normal_field: u64,
+    
+    #[idl_name("customName")]
+    pub renamed_field: String,
+    
+    #[skip]
+    pub skipped_field: bool,
+    
+    #[idl_name("renamedAndPadded")]
+    #[padding]
+    pub renamed_padding_field: [u8; 32],
+    
+    #[idl_type("u32")]
+    #[idl_name("customTypedField")]
+    pub custom_typed_field: SomeWrapper<u32>,
+}
+
+pub struct SomeWrapper<T>(pub T);

--- a/shank-macro-impl/src/parsed_struct/parsed_struct.rs
+++ b/shank-macro-impl/src/parsed_struct/parsed_struct.rs
@@ -44,6 +44,22 @@ impl StructField {
             }
         })
     }
+
+    /// Get the overridden name from the IdlName attribute if present
+    pub fn name_override(&self) -> Option<&String> {
+        self.attrs.iter().find_map(|attr| {
+            if let StructFieldAttr::IdlName(name) = attr {
+                Some(name)
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Check if this field should be skipped from the IDL
+    pub fn is_skipped(&self) -> bool {
+        self.attrs.iter().any(|attr| matches!(attr, StructFieldAttr::Skip))
+    }
 }
 
 impl TryFrom<&Field> for StructField {

--- a/shank-macro/src/lib.rs
+++ b/shank-macro/src/lib.rs
@@ -52,6 +52,31 @@ mod instruction;
 ///
 /// Indicates that a field is used for padding and should be marked as such in the IDL.
 ///
+/// ## `#[idl_name("name")]` attribute
+///
+/// Allows you to override the field name that appears in the IDL while keeping the original Rust field name.
+///
+/// ```
+/// #[derive(ShankAccount)]
+/// pub struct MyAccount {
+///     #[idl_name("displayName")]
+///     pub internal_name: String,
+/// }
+/// ```
+///
+/// ## `#[skip]` attribute
+///
+/// Excludes the field from the IDL entirely. The field will not appear in the generated IDL.
+///
+/// ```
+/// #[derive(ShankAccount)]
+/// pub struct MyAccount {
+///     pub public_field: u64,
+///     #[skip]
+///     pub internal_only_field: String,
+/// }
+/// ```
+///
 /// # Example
 ///
 /// ```
@@ -110,7 +135,10 @@ mod instruction;
 ///
 /// The fields of a _ShankAccount_ struct can reference other types as long as they are annotated
 /// with `ShankType`, `BorshSerialize` or `BorshDeserialize`.
-#[proc_macro_derive(ShankAccount, attributes(padding, seeds, idl_type))]
+#[proc_macro_derive(
+    ShankAccount,
+    attributes(padding, seeds, idl_type, idl_name, skip)
+)]
 pub fn shank_account(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     derive_account(input)
@@ -354,7 +382,7 @@ pub fn shank_context(input: TokenStream) -> TokenStream {
 ///
 /// The fields of a _ShankType_ struct or enum can reference other types as long as they are annotated
 /// with `ShankType`, `BorshSerialize` or `BorshDeserialize`.
-#[proc_macro_derive(ShankType)]
+#[proc_macro_derive(ShankType, attributes(idl_name, idl_type, skip))]
 pub fn shank_type(_input: TokenStream) -> TokenStream {
     // returns the token stream that was passed in (the macro is only an annotation for shank-idl
     // to export the type in the program's IDL)


### PR DESCRIPTION
This PR adds `#[skip]` and `#[idl_name("name")]` field attributes for `ShankAccount` and `ShankType` structs for more IDL output customization.

e.g.
```
#[derive(ShankAccount)]
pub struct FieldAttributesExample {
    pub normal_field: u64,
    
    #[idl_name("customName")]
    pub renamed_field: String,
    
    #[skip]
    pub skipped_field: bool,
    
    #[idl_name("renamedAndPadded")]
    #[padding]
    pub renamed_padding_field: [u8; 32],
    
    #[idl_type("u32")]
    #[idl_name("customTypedField")]
    pub custom_typed_field: SomeWrapper<u32>,
}
```