### PR TITLE
feat(shank-idl): support #[pod_sentinel] on enums for PodOption

### DIFF
--- a/shank-idl/src/idl_type_definition.rs
+++ b/shank-idl/src/idl_type_definition.rs
@@ -5,10 +5,17 @@ use serde::{Deserialize, Serialize};
 use shank_macro_impl::{
     custom_type::{CustomEnum, CustomStruct},
     parsed_enum::ParsedEnum,
-    parsed_struct::{ParsedStruct, StructAttr},
+    parsed_struct::{ParsedStruct, StructAttr, StructAttrs},
 };
 
 use crate::{idl_field::IdlField, idl_variant::IdlEnumVariant};
+
+fn extract_pod_sentinel(struct_attrs: &StructAttrs) -> Option<Vec<u8>> {
+    struct_attrs.items_ref().iter().find_map(|attr| match attr {
+        StructAttr::PodSentinel(sentinel) => Some(sentinel.clone()),
+        _ => None,
+    })
+}
 
 // -----------------
 // IdlTypeDefinitionTy
@@ -69,17 +76,7 @@ impl TryFrom<ParsedStruct> for IdlTypeDefinition {
 
     fn try_from(strct: ParsedStruct) -> Result<Self> {
         let name = strct.ident.to_string();
-
-        // Extract pod_sentinel from struct attributes
-        let pod_sentinel =
-            strct
-                .struct_attrs
-                .items_ref()
-                .iter()
-                .find_map(|attr| match attr {
-                    StructAttr::PodSentinel(sentinel) => Some(sentinel.clone()),
-                    _ => None,
-                });
+        let pod_sentinel = extract_pod_sentinel(&strct.struct_attrs);
 
         let ty: IdlTypeDefinitionTy = strct.try_into()?;
         Ok(Self {
@@ -95,14 +92,7 @@ impl TryFrom<CustomStruct> for IdlTypeDefinition {
 
     fn try_from(strct: CustomStruct) -> Result<Self> {
         let name = strct.ident.to_string();
-
-        // Extract pod_sentinel from struct attributes
-        let pod_sentinel = strct.0.struct_attrs.items_ref().iter().find_map(
-            |attr| match attr {
-                StructAttr::PodSentinel(sentinel) => Some(sentinel.clone()),
-                _ => None,
-            },
-        );
+        let pod_sentinel = extract_pod_sentinel(&strct.0.struct_attrs);
 
         let ty: IdlTypeDefinitionTy = strct.0.try_into()?;
         Ok(Self {
@@ -118,17 +108,7 @@ impl TryFrom<CustomEnum> for IdlTypeDefinition {
 
     fn try_from(enm: CustomEnum) -> Result<Self> {
         let name = enm.ident.to_string();
-
-        // Extract pod_sentinel from enum attributes
-        let pod_sentinel =
-            enm.0
-                .struct_attrs
-                .items_ref()
-                .iter()
-                .find_map(|attr| match attr {
-                    StructAttr::PodSentinel(sentinel) => Some(sentinel.clone()),
-                    _ => None,
-                });
+        let pod_sentinel = extract_pod_sentinel(&enm.0.struct_attrs);
 
         let ty: IdlTypeDefinitionTy = enm.0.try_into()?;
         Ok(Self {

--- a/shank-idl/src/idl_type_definition.rs
+++ b/shank-idl/src/idl_type_definition.rs
@@ -56,7 +56,11 @@ pub struct IdlTypeDefinition {
     pub name: String,
     #[serde(rename = "type")]
     pub ty: IdlTypeDefinitionTy,
-    #[serde(skip_serializing_if = "Option::is_none", default, rename = "podSentinel")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        rename = "podSentinel"
+    )]
     pub pod_sentinel: Option<Vec<u8>>,
 }
 
@@ -67,15 +71,22 @@ impl TryFrom<ParsedStruct> for IdlTypeDefinition {
         let name = strct.ident.to_string();
 
         // Extract pod_sentinel from struct attributes
-        let pod_sentinel = strct.struct_attrs.items_ref().iter().find_map(|attr| {
-            match attr {
-                StructAttr::PodSentinel(sentinel) => Some(sentinel.clone()),
-                _ => None,
-            }
-        });
+        let pod_sentinel =
+            strct
+                .struct_attrs
+                .items_ref()
+                .iter()
+                .find_map(|attr| match attr {
+                    StructAttr::PodSentinel(sentinel) => Some(sentinel.clone()),
+                    _ => None,
+                });
 
         let ty: IdlTypeDefinitionTy = strct.try_into()?;
-        Ok(Self { ty, name, pod_sentinel })
+        Ok(Self {
+            ty,
+            name,
+            pod_sentinel,
+        })
     }
 }
 
@@ -86,15 +97,19 @@ impl TryFrom<CustomStruct> for IdlTypeDefinition {
         let name = strct.ident.to_string();
 
         // Extract pod_sentinel from struct attributes
-        let pod_sentinel = strct.0.struct_attrs.items_ref().iter().find_map(|attr| {
-            match attr {
+        let pod_sentinel = strct.0.struct_attrs.items_ref().iter().find_map(
+            |attr| match attr {
                 StructAttr::PodSentinel(sentinel) => Some(sentinel.clone()),
                 _ => None,
-            }
-        });
+            },
+        );
 
         let ty: IdlTypeDefinitionTy = strct.0.try_into()?;
-        Ok(Self { ty, name, pod_sentinel })
+        Ok(Self {
+            ty,
+            name,
+            pod_sentinel,
+        })
     }
 }
 
@@ -103,8 +118,23 @@ impl TryFrom<CustomEnum> for IdlTypeDefinition {
 
     fn try_from(enm: CustomEnum) -> Result<Self> {
         let name = enm.ident.to_string();
+
+        // Extract pod_sentinel from enum attributes
+        let pod_sentinel =
+            enm.0
+                .struct_attrs
+                .items_ref()
+                .iter()
+                .find_map(|attr| match attr {
+                    StructAttr::PodSentinel(sentinel) => Some(sentinel.clone()),
+                    _ => None,
+                });
+
         let ty: IdlTypeDefinitionTy = enm.0.try_into()?;
-        // Enums don't currently support pod_sentinel
-        Ok(Self { ty, name, pod_sentinel: None })
+        Ok(Self {
+            ty,
+            name,
+            pod_sentinel,
+        })
     }
 }

--- a/shank-idl/tests/fixtures/accounts/single_file/pod_option_enum_sentinel.rs
+++ b/shank-idl/tests/fixtures/accounts/single_file/pod_option_enum_sentinel.rs
@@ -1,0 +1,19 @@
+use shank::{ShankAccount, ShankType};
+
+/// Generic PodOption type (normally from podded crate)
+pub struct PodOption<T>(pub T);
+
+/// Enum WITH pod_sentinel - should work with PodOption
+#[derive(ShankType)]
+#[pod_sentinel(255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)]
+pub enum Condition {
+    TimeAbsolute { time: i64 },
+    TimeRelative { offset: i64 },
+}
+
+/// Account using PodOption with an enum that has a sentinel
+#[derive(ShankAccount)]
+pub struct AccountWithEnumPodOption {
+    /// This should succeed because Condition has pod_sentinel
+    pub optional_condition: PodOption<Condition>,
+}

--- a/shank-macro-impl/src/parsed_enum/parsed_enum.rs
+++ b/shank-macro-impl/src/parsed_enum/parsed_enum.rs
@@ -49,8 +49,7 @@ impl TryFrom<&ItemEnum> for ParsedEnum {
             })
             .collect::<ParseResult<Vec<ParsedEnumVariant>>>()?;
 
-        let struct_attrs = StructAttrs::try_from(attrs.as_slice())
-            .unwrap_or_default();
+        let struct_attrs = StructAttrs::try_from(attrs.as_slice())?;
 
         Ok(ParsedEnum {
             ident: ident.clone(),

--- a/shank-macro-impl/src/parsed_enum/parsed_enum.rs
+++ b/shank-macro-impl/src/parsed_enum/parsed_enum.rs
@@ -3,8 +3,9 @@ use std::convert::TryFrom;
 use syn::{Attribute, Error as ParseError, ItemEnum, Result as ParseResult};
 
 use super::ParsedEnumVariant;
+use crate::parsed_struct::StructAttrs;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct ParsedEnum {
     /// The enum itself, i.e. CreateOwner
     pub ident: syn::Ident,
@@ -14,6 +15,9 @@ pub struct ParsedEnum {
 
     /// Attributes found on the enum
     pub attrs: Vec<Attribute>,
+
+    /// Parsed enum-level attributes (e.g. pod_sentinel)
+    pub struct_attrs: StructAttrs,
 }
 
 impl TryFrom<&ItemEnum> for ParsedEnum {
@@ -45,10 +49,14 @@ impl TryFrom<&ItemEnum> for ParsedEnum {
             })
             .collect::<ParseResult<Vec<ParsedEnumVariant>>>()?;
 
+        let struct_attrs = StructAttrs::try_from(attrs.as_slice())
+            .unwrap_or_default();
+
         Ok(ParsedEnum {
             ident: ident.clone(),
             variants,
             attrs: attrs.clone(),
+            struct_attrs,
         })
     }
 }


### PR DESCRIPTION
Previously, only structs had their #[pod_sentinel] attribute parsed and propagated to the IDL. Enums with #[pod_sentinel] were ignored, causing PodOption<EnumType> to fail validation with "does not define [pod_sentinel(...)]" even when the attribute was present.

- Add `struct_attrs: StructAttrs` field to `ParsedEnum`, mirroring `ParsedStruct`, so enum-level attributes are parsed at construction
- Update `TryFrom<CustomEnum> for IdlTypeDefinition` to extract `pod_sentinel` from the pre-parsed attrs (matching the struct impl)
- Add test fixture and test for PodOption<Enum> with pod_sentinel