### PR TITLE
add line info to syn parse error

### DIFF
--- a/shank-macro-impl/Cargo.toml
+++ b/shank-macro-impl/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.48"
-proc-macro2 = "1.0.32"
+proc-macro2 = { version = "1.0.32", features = ["span-locations"] }
 quote = "1.0.21"
 serde = { version = "1.0.130", features = ["derive"] }
 syn = { version = "1.0.82", features = ["extra-traits", "full"] }

--- a/shank-macro-impl/src/krate/module_context.rs
+++ b/shank-macro-impl/src/krate/module_context.rs
@@ -4,7 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use syn::{Error as ParseError, Result as ParseResult};
+use syn::Error as ParseError;
 
 /// Module parse context
 ///
@@ -42,7 +42,16 @@ impl ParsedModule {
     ) -> Result<BTreeMap<String, ParsedModule>, anyhow::Error> {
         let mut modules = BTreeMap::new();
 
-        let root_file = syn::parse_file(&root_content)?;
+        let root_file = syn::parse_file(&root_content).map_err(|e| {
+            let loc = e.span().start();
+            anyhow::anyhow!(
+                "failed to parse {}:{}:{}: {}",
+                root.display(),
+                loc.line,
+                loc.column,
+                e,
+            )
+        })?;
         let root_mod = Self::new(
             String::new(),
             root.to_owned(),
@@ -90,7 +99,7 @@ impl ParsedModule {
         parent_file: &Path,
         parent_path: &str,
         item: syn::ItemMod,
-    ) -> ParseResult<Self> {
+    ) -> anyhow::Result<Self> {
         Ok(match item.content {
             Some((_, items)) => {
                 // The module content is within the parent file being parsed
@@ -126,7 +135,17 @@ impl ParsedModule {
                     .map_err(|_| {
                         ParseError::new_spanned(&item, "could not read file")
                     })?;
-                let mod_file = syn::parse_file(&mod_file_content)?;
+                let mod_file =
+                    syn::parse_file(&mod_file_content).map_err(|e| {
+                        let loc = e.span().start();
+                        anyhow::anyhow!(
+                            "failed to parse {}:{}:{}: {}",
+                            mod_file_path.display(),
+                            loc.line,
+                            loc.column,
+                            e,
+                        )
+                    })?;
 
                 Self::new(
                     parent_path.to_owned(),


### PR DESCRIPTION
enrich the error produced by syn when it fails to parse a file. so instead of throwing a generic error like

```
$ shank idl
shank DEBUG No crate_root provided, assuming in current dir
shank DEBUG out_dir is relative, resolving from current dir
Error: unexpected token
```

it produces a more meaningful result

```
$ shank idl
shank DEBUG No crate_root provided, assuming in current dir
shank DEBUG out_dir is relative, resolving from current dir
Error: failed to parse /home/skrrb/foo.rs:120:8: unexpected token
```